### PR TITLE
[LIMS-1628] Highlight grid boxes stored at eBIC

### DIFF
--- a/src/components/containers/Generic.test.tsx
+++ b/src/components/containers/Generic.test.tsx
@@ -25,6 +25,10 @@ const falconTube = {
 defaultShipment.shipment.activeItem = falconTube as TreeData<BaseShipmentItem>;
 
 const populatedContainer = { ...falconTube, children: [gridBox] } as TreeData<BaseShipmentItem>;
+const populatedContainerStored = {
+  ...falconTube,
+  children: [{ ...gridBox, data: { ...gridBox.data, store: true } }],
+} as TreeData<BaseShipmentItem>;
 
 describe("Generic Container", () => {
   it("should fire creation callback if apply clicked", async () => {
@@ -106,5 +110,19 @@ describe("Generic Container", () => {
 
     expect(screen.queryByText(/remove/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/add/i)).not.toBeInTheDocument();
+  });
+
+  it("should highlight grid boxes stored at eBIC", () => {
+    renderAndInjectForm(<GenericContainer parentId='1' />, {
+      preloadedState: {
+        shipment: {
+          ...initialState,
+          activeItem: populatedContainerStored,
+          isEdit: true,
+        },
+      },
+    });
+
+    expect(screen.getByLabelText("gridBox")).toHaveAttribute("title", "Stored at eBIC");
   });
 });

--- a/src/components/containers/Generic.tsx
+++ b/src/components/containers/Generic.tsx
@@ -67,23 +67,28 @@ export const GenericContainer = ({
         Contents
       </Heading>
       <List overflowY='scroll' h='80%'>
-        {(currentContainer!.children ?? []).map((item) => (
-          <ListItem
-            key={item.id}
-            p='5px'
-            display='flex'
-            bg='diamond.50'
-            mb='3px'
-            borderRadius='4px'
-          >
-            <Text flex='1 0 0'>{item.name}</Text>
-            {formContext !== undefined && (
-              <Button bg='red.600' size='xs' onClick={() => handleRemoveSample(item)}>
-                Remove
-              </Button>
-            )}
-          </ListItem>
-        ))}
+        {(currentContainer!.children ?? []).map((item) => {
+          const isStored = childSpecificType === "gridBox" && item.data.store;
+          return (
+            <ListItem
+              key={item.id}
+              p='5px'
+              display='flex'
+              bg={isStored ? "#46BDB2" : "diamond.50"}
+              mb='3px'
+              borderRadius='4px'
+              title={isStored ? "Stored at eBIC" : undefined}
+              aria-label={item.name}
+            >
+              <Text flex='1 0 0'>{item.name}</Text>
+              {formContext !== undefined && (
+                <Button bg='red.600' size='xs' onClick={() => handleRemoveSample(item)}>
+                  Remove
+                </Button>
+              )}
+            </ListItem>
+          );
+        })}
         <ListItem mt='5px'>
           {formContext !== undefined && (
             <Button w='100%' size='sm' onClick={onOpen}>

--- a/src/components/containers/Puck.test.tsx
+++ b/src/components/containers/Puck.test.tsx
@@ -20,6 +20,11 @@ const populatedContainer = {
   children: [{ ...gridBox, data: { location: 5 } }],
 } as TreeData<BaseShipmentItem>;
 
+const populatedContainerStored = {
+  ...puck,
+  children: [{ ...gridBox, data: { location: 5, store: true } }],
+} as TreeData<BaseShipmentItem>;
+
 describe("Puck", () => {
   it.each([
     { count: 12, type: "1" },
@@ -76,6 +81,20 @@ describe("Puck", () => {
 
     fireEvent.click(screen.getByTestId("5-empty"));
     screen.getByText("Select");
+  });
+
+  it("should highlight items stored at eBIC", () => {
+    renderAndInjectForm(<Puck parentId='1' />, {
+      preloadedState: {
+        shipment: {
+          ...testInitialState,
+          activeItem: populatedContainerStored,
+          isEdit: true,
+        },
+      },
+    });
+
+    expect(screen.getByText("5")).toHaveAttribute("title", "Stored at eBIC");
   });
 
   it("should fire remove callback when remove is clicked", async () => {

--- a/src/components/containers/Puck.tsx
+++ b/src/components/containers/Puck.tsx
@@ -8,7 +8,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { ContainerProps, useChildLocationManager } from ".";
 import Image from "next/image";
-import { GenericChildSlot } from "@/components/containers/child";
+import { GenericChildSlot, GenericChildSlotProps } from "@/components/containers/child";
 import { CrossShipmentSelector } from "@/components/containers/CrossShipmentSelector";
 import { ContainerItem } from "@/types/generic";
 
@@ -125,16 +125,22 @@ export const Puck = ({
       )}
       <Box w='296px' h='296px' position='relative' margin='20px'>
         <Image width={296} height={296} alt='Puck' src={imageLocation} />
-        {positions.items.map((item, i) => (
-          <GenericChildSlot
-            key={i}
-            label={i + 1}
-            hasSample={item.item !== null}
-            onClick={() => handleGridClicked(item.item, i)}
-            left={`${item.x}px`}
-            top={`${item.y}px`}
-          />
-        ))}
+        {positions.items.map((item, i) => {
+          const props: GenericChildSlotProps = {
+            label: i + 1,
+            hasSample: item.item !== null,
+            onClick: () => handleGridClicked(item.item, i),
+            left: `${item.x}px`,
+            top: `${item.y}px`,
+          };
+
+          if (item.item && item.item.data.store === true) {
+            props.bgColor = "#46BDB2";
+            props.title = "Stored at eBIC";
+          }
+
+          return <GenericChildSlot key={i} {...props} />;
+        })}
         {parentType === "shipment" ? (
           <ChildSelector
             childrenType='gridBox'


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1628](https://jira.diamond.ac.uk/browse/LIMS-1628)

**Summary**:

Grid boxes which are stored at eBIC are now highlighted in cyan, and have a tooltip associated with them

**Changes**:

* Grid boxes which are stored at eBIC are now highlighted

**To test**:

* Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100, create a new shipment, go to the grid box creation page, and tick "store at eBIC"
* Create grid box
* Add grid box to a puck, verify if puck slot is now highlighted in cyan
* Change container type from puck to falcon tube, check that the slot is still highlighted in cyan

![image](https://github.com/user-attachments/assets/39193b03-3cb4-418c-95da-1af90104f355)
![image](https://github.com/user-attachments/assets/8ec98791-f338-490b-8e84-c9408ee80023)
