### PR TITLE
Include additional tracking label instructions

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.tsx
@@ -86,10 +86,25 @@ const SubmissionOverview = async (props: { params: Promise<ShipmentParams> }) =>
               <Heading alignSelf='start'>Contents</Heading>
               <DynamicFormView formType={shipmentData.formModel} data={shipmentData.counts} />
             </VStack>
-            <Text fontSize='18px' my='1em'>
+            <Text fontSize='18px' mt='1em'>
               If you <b>do not plan to use Diamond&#39;s own courier</b> (DHL, on Diamond&#39;s
               account), you <b>do not need to arrange shipping</b> through Diamond. When using your
               own courier, ensure the labels provided by your courier are securely affixed.
+            </Text>
+            <Text fontSize='18px'>
+              If you plan to arrange shipping through Diamond,{" "}
+              <b>
+                print the tracking labels after you&#39;re finished setting up your shipping details
+              </b>
+              . This can be done on the{" "}
+              <Link
+                textDecoration='underline'
+                color='diamond.600'
+                href={`/proposals/${params.proposalId}/sessions/${params.visitNumber}/shipments/${params.shipmentId}`}
+              >
+                sample collection summary page
+              </Link>
+              . You will be automatically redirected to that page once you finish setting up shipping.
             </Text>
             <Text fontSize='18px'>
               Tracking labels <b>must</b> be securely affixed to the outside of both dewars and


### PR DESCRIPTION
**Summary**:

To reduce confusion, tracking label instructions have been extended to make it clear users should print them after setting up shipping if shipping through Diamond.

**Changes**:

* Include additional tracking label instructions

**To test**:

* Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/117/submitted, check if a new paragraph has been added, explaining that users should print labels after shipping has been set up.