### PR TITLE
[LIMS-1769] Display sample information for samples in grid box slots

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.tsx
@@ -88,7 +88,7 @@ const ReturnRequests = async (props: { params: Promise<ShipmentParams> }) => {
                     <Heading size='md'>Transport History</Heading>
                     <Box w='100%' overflowY='scroll' h='20em' p='1em'>
                       {tlc.history ? (
-                        <Stepper index={0} orientation='vertical' maxH="400px" gap='0' size='sm'>
+                        <Stepper index={0} orientation='vertical' maxH='400px' gap='0' size='sm'>
                           {tlc.history.map((item, index) => (
                             <Step key={index}>
                               <StepIndicator

--- a/src/components/containers/ChildSelector.test.tsx
+++ b/src/components/containers/ChildSelector.test.tsx
@@ -159,4 +159,21 @@ describe("Child Selector", () => {
 
     expect(screen.getByText("selectable-child")).toBeInTheDocument();
   });
+
+  it("should display details if child is sample", () => {
+    renderWithProviders(
+      <ChildSelector
+        childrenType='sample'
+        isOpen={true}
+        onClose={() => {}}
+        selectableChildren={[
+          { id: 1, name: "selectable-child", data: { type: "Sample", concentration: 123 } },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("selectable-child")).toBeInTheDocument();
+    expect(screen.getByText("Concentration:")).toBeInTheDocument();
+    expect(screen.getByText("123")).toBeInTheDocument();
+  });
 });

--- a/src/components/containers/ChildSelector.tsx
+++ b/src/components/containers/ChildSelector.tsx
@@ -8,6 +8,7 @@ import {
   Checkbox,
   CheckboxGroup,
   Divider,
+  Grid,
   HStack,
   Heading,
   Modal,
@@ -28,6 +29,67 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
+
+interface ChildItemDetailsProps {
+  childType: string;
+  childData: TreeData<BaseShipmentItem>;
+  childId: number;
+  hasCheckbox?: boolean;
+}
+
+interface ChildItemDetailsFieldProps {
+  value?: number | string | null;
+  label: string;
+  measurementUnit?: string;
+}
+
+const ChildItemDetailsField = ({ value, label, measurementUnit }: ChildItemDetailsFieldProps) => (
+  <HStack w='100%' color='#686464'>
+    <Text w='140px' fontWeight='800'>
+      {label}:
+    </Text>
+    <Text>{value || "?"}</Text>
+    {value && <Text>{measurementUnit}</Text>}
+  </HStack>
+);
+
+const ChildItemDetails = ({
+  childType,
+  childData,
+  childId,
+  hasCheckbox = false,
+}: ChildItemDetailsProps) => (
+  <VStack w='100%' key={childId} borderBottom='1px solid' borderColor='diamond.200' py='10px'>
+    <HStack w='100%'>
+      <Stat>
+        <StatLabel>{childType}</StatLabel>
+        <StatNumber>{childData.name}</StatNumber>
+        {childType === "Sample" && (
+          <Grid w='100%' gap='0' templateColumns='repeat(2, 1fr)' mt='10px'>
+            <ChildItemDetailsField
+              label='Concentration'
+              value={childData.data.concentration}
+              measurementUnit='mg/ml'
+            />
+            <ChildItemDetailsField label='Buffer' value={childData.data.buffer} />
+            <ChildItemDetailsField
+              label='Support Material'
+              value={childData.data.supportMaterial}
+            />
+            <ChildItemDetailsField label='Foil' value={childData.data.foil} />
+            <ChildItemDetailsField label='Mesh' value={childData.data.mesh} />
+            <ChildItemDetailsField label='Hole Diameter' value={childData.data.hole} />
+          </Grid>
+        )}
+      </Stat>
+      {hasCheckbox ? (
+        <Checkbox value={childId.toString()} size='lg' />
+      ) : (
+        <Radio borderColor='black' value={childId.toString()} size='lg' />
+      )}
+    </HStack>
+  </VStack>
+);
 
 export const ChildSelector = ({
   selectedItem,
@@ -136,48 +198,31 @@ export const ChildSelector = ({
             </Box>
           )}
           {!readOnly && (
-            <>
+            <VStack w='100%'>
               {unassignedItems && unassignedItems.length > 0 ? (
                 acceptMultiple ? (
-                  <VStack>
-                    <CheckboxGroup onChange={(values) => setSelectedItems(values.map(Number))}>
-                      {unassignedItems.map((item, i) => (
-                        <HStack
-                          w='100%'
-                          key={item.id}
-                          borderBottom='1px solid'
-                          borderColor='diamond.200'
-                          py='10px'
-                        >
-                          <Stat>
-                            <StatLabel>{childrenTypeData.data.singular}</StatLabel>
-                            <StatNumber>{item.name}</StatNumber>
-                          </Stat>
-                          <Checkbox value={i.toString()} size='lg' />
-                        </HStack>
-                      ))}
-                    </CheckboxGroup>
-                  </VStack>
+                  <CheckboxGroup onChange={(values) => setSelectedItems(values.map(Number))}>
+                    {unassignedItems.map((item, i) => (
+                      <ChildItemDetails
+                        key={i}
+                        childType={childrenTypeData.data.singular}
+                        childData={item}
+                        childId={i}
+                        hasCheckbox={true}
+                      />
+                    ))}
+                  </CheckboxGroup>
                 ) : (
-                  <VStack w='100%'>
-                    <RadioGroup w='100%' onChange={(index) => setSelectedItems([Number(index)])}>
-                      {unassignedItems.map((item, i) => (
-                        <HStack
-                          w='100%'
-                          key={item.id}
-                          borderBottom='1px solid'
-                          borderColor='diamond.200'
-                          py='10px'
-                        >
-                          <Stat>
-                            <StatLabel>{childrenTypeData.data.singular}</StatLabel>
-                            <StatNumber>{item.name}</StatNumber>
-                          </Stat>
-                          <Radio borderColor='black' value={i.toString()} size='lg' />
-                        </HStack>
-                      ))}
-                    </RadioGroup>
-                  </VStack>
+                  <RadioGroup w='100%' onChange={(index) => setSelectedItems([Number(index)])}>
+                    {unassignedItems.map((item, i) => (
+                      <ChildItemDetails
+                        key={i}
+                        childType={childrenTypeData.data.singular}
+                        childData={item}
+                        childId={i}
+                      />
+                    ))}
+                  </RadioGroup>
                 )
               ) : (
                 <Text py='2' color='gray.600'>
@@ -186,7 +231,7 @@ export const ChildSelector = ({
                   {childrenTypeData.data.singular.toLowerCase()} from its container.
                 </Text>
               )}
-            </>
+            </VStack>
           )}
         </ModalBody>
         <ModalFooter>

--- a/src/components/containers/index.test.tsx
+++ b/src/components/containers/index.test.tsx
@@ -96,4 +96,15 @@ describe("Container Child Location Manager", () => {
 
     expect(Item.patch).not.toHaveBeenCalled();
   });
+
+  it("should not redirect if parent does not exist and couldn't be autocreated", async () => {
+    vi.mocked(Item.create).mockReturnValueOnce(new Promise(() => null));
+    const setLocation = generateHook(
+      { parentId: "1" },
+      { preloadedState: { shipment: { ...initialState, activeItem: puck, isEdit: true } } },
+    );
+    await setLocation(1, { id: 1, data: { type: "puck" }, name: "puck" }, 1);
+
+    expect(Item.patch).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/containers/index.tsx
+++ b/src/components/containers/index.tsx
@@ -86,6 +86,11 @@ export const useChildLocationManager = ({
           parent,
           parentType,
         );
+
+        if (!receivedItem) {
+          return;
+        }
+
         newItem = Array.isArray(receivedItem) ? receivedItem[0] : receivedItem;
         actualContainerId = newItem.id;
       } else {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1769](https://jira.diamond.ac.uk/browse/LIMS-1769)

**Summary**:

This adds extra details to help discern between samples when assigning them to pucks, as many samples of the same protein might be created, with different concentrations/buffers/etc.

**Changes**:
- Display sample information for samples in grid box slots

**To test**:

- Go to any shipment (such as https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118), start editing, create one (or more samples)
- Move on to grid box creation (https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/gridBox/new/edit) and pick a slot
- Check if sample details are displayed:
![image](https://github.com/user-attachments/assets/4b7807d1-33a8-4609-81e5-a8cb9997966d)
- Create a new grid box, move on to the puck page (https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/puck/new/edit), check if the old modal still stands
![image](https://github.com/user-attachments/assets/0480195d-983e-4eb5-92ba-a7cd4c0e3c38)

