### PR TITLE
Display message on submit page if sample collection does not exist

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.tsx
@@ -11,9 +11,7 @@ import {
   Link,
   Step,
   StepDescription,
-  StepIcon,
   StepIndicator,
-  StepNumber,
   StepSeparator,
   StepStatus,
   StepTitle,
@@ -21,7 +19,6 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { steps } from "framer-motion";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.test.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.test.tsx
@@ -43,7 +43,7 @@ describe("Sample Collection Submission Overview", () => {
       http.get(
         "http://localhost/api/shipments/:shipmentId",
         () =>
-          HttpResponse.json({ ...defaultData, data: { shipmentRequest: 123 } }, { status: 200 }),
+          HttpResponse.json({ ...defaultData, data: { shipmentRequest: 123 } }),
         { once: true },
       ),
     );
@@ -52,5 +52,20 @@ describe("Sample Collection Submission Overview", () => {
 
     expect(screen.getByText(/view shipping information/i)).toBeInTheDocument();
     expect(screen.getByText(/the shipping process has already been started/i)).toBeInTheDocument();
+  });
+
+  it("should display message if sample collection does not exist", async () => {
+    server.use(
+      http.get(
+        "http://localhost/api/shipments/:shipmentId",
+        () =>
+          HttpResponse.json({ }, { status: 404 }),
+        { once: true },
+      ),
+    );
+
+    render(await SubmissionOverview(baseShipmentParams));
+
+    expect(screen.getByText(/sample collection unavailable/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Summary**:

Previously, an error was thrown if a user manually changed the URL to point to a sample collection which did not exist in the `submitted` page. This now displays an error message and a link back to the dashboard.

**Changes**:
- Display message on submit page if sample collection does not exist

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/999999/submitted (or any invalid sample collection/shipment) and check if "sample collection unavailable" is displayed
