### PR TITLE
[LIMS-1790] Update instructions for labels, improve button logic

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/booking-and-labels/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/booking-and-labels/page.tsx
@@ -49,10 +49,16 @@ const BookingAndLabelsPage = async (props: { params: Promise<ShipmentParams> }) 
         <List spacing='3em'>
           <ListItem>
             <Heading size='lg'>Tracking labels</Heading>
-            <Text my='1em'>
+            <Text mt='1em'>
               Print tracking labels and affix them to the outside of the dewar and dewar case. If
               you are sending multiple dewars, ensure the code on the label matches the code on the
               dewar.
+            </Text>
+            <Text my='1em'>
+              If a dewar doesn&#39;t have a barcode (such as the ones on the last page) already, cut
+              out the barcode on the last page and affix it to the dewar. If you&#39;re sending
+              multiple dewars, ensure the dewar matches the barcode you&#39;ve selected for it
+              previously.
             </Text>
             <Button
               as={NextLink}

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.test.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.test.tsx
@@ -1,6 +1,6 @@
 import { defaultData } from "@/mocks/handlers";
 import { server } from "@/mocks/server";
-import { baseShipmentParams, renderWithProviders } from "@/utils/test-utils";
+import { baseShipmentParams, dewar, renderWithProviders } from "@/utils/test-utils";
 import { screen } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import ShipmentHome from "./page";
@@ -47,7 +47,7 @@ describe("Sample Collection Submission Overview", () => {
     server.use(
       http.get(
         "http://localhost/api/shipments/:shipmentId",
-        () => HttpResponse.json({ ...defaultData, data: { status: "Booked" } }),
+        () => HttpResponse.json({ ...defaultData, data: { shipmentRequest: 1 } }),
         { once: true },
       ),
     );
@@ -86,6 +86,21 @@ describe("Sample Collection Submission Overview", () => {
 
   it("should disable booking and labels link if no dewars are present in the sample collection", async () => {
     const noDewarData = structuredClone(defaultData);
+
+    noDewarData.children = [];
+    server.use(
+      http.get("http://localhost/api/shipments/:shipmentId", () => HttpResponse.json(noDewarData), {
+        once: true,
+      }),
+    );
+    renderWithProviders(await ShipmentHome(baseShipmentParams));
+
+    expect(screen.getByTestId("booking-label")).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("should disable booking and labels link if shipment hasn't been pushed to ISPyB", async () => {
+    let noDewarData = structuredClone(defaultData);
+    noDewarData = { ...defaultData, children: [dewar] };
 
     noDewarData.children = [];
     server.use(

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.tsx
@@ -148,7 +148,7 @@ const ShipmentHome = async (props: { params: Promise<ShipmentParams> }) => {
                 title='Edit Sample Collection'
                 as={NextLink}
                 href={`${params.shipmentId}/edit`}
-                isDisabled={shipmentData.dispatch.status === "Booked"}
+                isDisabled={!!shipmentData.dispatch.shipmentRequest}
               >
                 Edit sample collection contents, or add new items
               </TwoLineLink>
@@ -156,7 +156,7 @@ const ShipmentHome = async (props: { params: Promise<ShipmentParams> }) => {
                 title={`${shipmentData.preSessionInfo ? "Edit" : "Set"} Pre-Session Information`}
                 as={NextLink}
                 href={`${params.shipmentId}/pre-session`}
-                isDisabled={shipmentData.dispatch.status === "Booked"}
+                isDisabled={!!shipmentData.dispatch.shipmentRequest}
               >
                 Set imaging conditions, grid/data acquisition parameters
               </TwoLineLink>
@@ -189,7 +189,7 @@ const ShipmentHome = async (props: { params: Promise<ShipmentParams> }) => {
                 title='Booking & Labels'
                 as={NextLink}
                 href={`${params.shipmentId}/booking-and-labels`}
-                isDisabled={!shipmentData.counts.Dewar}
+                isDisabled={!shipmentData.counts.Dewar || !shipmentData.dispatch.externalId}
                 data-testid='booking-label'
               >
                 Book pickup with courier or print tracking labels

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.test.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.test.tsx
@@ -42,8 +42,7 @@ describe("Sample Collection Submission Overview", () => {
     server.use(
       http.get(
         "http://localhost/api/shipments/:shipmentId",
-        () =>
-          HttpResponse.json({ ...defaultData, data: { shipmentRequest: 123 } }),
+        () => HttpResponse.json({ ...defaultData, data: { shipmentRequest: 123 } }),
         { once: true },
       ),
     );
@@ -58,8 +57,7 @@ describe("Sample Collection Submission Overview", () => {
     server.use(
       http.get(
         "http://localhost/api/shipments/:shipmentId",
-        () =>
-          HttpResponse.json({ }, { status: 404 }),
+        () => HttpResponse.json({}, { status: 404 }),
         { once: true },
       ),
     );

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.tsx
@@ -46,13 +46,15 @@ const SubmissionOverview = async (props: { params: Promise<ShipmentParams> }) =>
   const shipmentData = await getShipment(params.shipmentId);
 
   if (shipmentData === null) {
-    return <VStack w='100%' mt='3em'>
-      <Heading variant='notFound'>Sample Collection Unavailable</Heading>
-      <Text>This sample collection does not exist or you do not have permission to view it.</Text>
-      <Link as={NextLink} href='..'>
-        Return to session page
-      </Link>
-    </VStack>;
+    return (
+      <VStack w='100%' mt='3em'>
+        <Heading variant='notFound'>Sample Collection Unavailable</Heading>
+        <Text>This sample collection does not exist or you do not have permission to view it.</Text>
+        <Link as={NextLink} href='..'>
+          Return to session page
+        </Link>
+      </VStack>
+    );
   }
 
   return (

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,9 +1,10 @@
-import { pluralToSingular } from "@/mappings/pages";
+import { BaseShipmentItem, pluralToSingular } from "@/mappings/pages";
 import { http, HttpResponse } from "msw";
 
-export const defaultData = {
+export const defaultData: BaseShipmentItem = {
   id: 1,
   name: "Shipment",
+  type: "shipment",
   data: { proposalNumber: "123", proposalCode: "cm", visitNumber: 1 },
   children: [
     {

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -130,6 +130,12 @@ export const puck: TreeData<BaseShipmentItem> = {
   data: { type: "puck", registeredContainer: "DLS-0001" },
 };
 
+export const dewar: TreeData<BaseShipmentItem> = {
+  id: 15,
+  name: "dewar",
+  data: { type: "dewar", code: "DLS-0001" },
+};
+
 export const cane: TreeData<BaseShipmentItem> = {
   id: 10,
   name: "cane",


### PR DESCRIPTION
**JIRA ticket**: [TICKET-123](https://link.to.jira)

**Summary**:

To match the instructions displayed with the shipping labels, the text on the frontend had to be updated. Additionally, a few buttons now use different methodologies to determine whether they should be disabled or not.

**Changes**:
- Update instructions for labels
- Improve button disabling logic

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/117, check if the "edit sample collection" and "edit pre-session information" buttons are disabled
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118, check if both buttons are enabled
