### PR TITLE
[LIMS-1781] Disallow users from importing samples which have already been imported

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.tsx
@@ -117,14 +117,18 @@ const ImportSamplesPageContent = ({ params }: { params: ShipmentParams }) => {
             }}
           >
             <VStack w='100%' divider={<Divider />}>
-              {samples.map((sample, i) => (
-                <Checkbox w='100%' value={i.toString()} key={i}>
-                  <Heading flex='1 0 0' size='md'>
-                    {sample.name} <Tag colorScheme='purple'>{sample.parentShipmentName}</Tag>
-                  </Heading>
-                  <Text>{sample.comments}</Text>
-                </Checkbox>
-              ))}
+              {samples.map((sample, i) => {
+                const hasChildren = !!(sample.derivedSamples && sample.derivedSamples.length > 0);
+                return (
+                  <Checkbox isDisabled={hasChildren} w='100%' value={i.toString()} key={i}>
+                    <Heading flex='1 0 0' size='md'>
+                      {sample.name} <Tag colorScheme='purple'>{sample.parentShipmentName}</Tag>
+                    </Heading>
+                    <Text>{sample.comments}</Text>
+                    {hasChildren && <Text>Sample already imported</Text>}
+                  </Checkbox>
+                );
+              })}
             </VStack>
           </CheckboxGroup>
         </VStack>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1781](https://jira.diamond.ac.uk/browse/LIMS-1781)

**Summary**:

Since we don't want to have users creating samples that "fork" off the same physical sample for the moment, all samples will only be able to parent one sample at a time. No check is being made in the backend, as this should still be available programatically.

**Changes**:
- Disallow users from importing samples which have already been imported

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100
- Tick "use existing samples", create a new shipment
- Select "100" as the source session
- Check if one of the samples is disabled:

<img width="431" height="216" alt="image" src="https://github.com/user-attachments/assets/8dc36695-6467-484e-b4be-2e54dccb7dea" />
