### PR TITLE
Rename mentions of sample instances to grids

### DIFF
--- a/e2e/shipmentsPage.spec.ts
+++ b/e2e/shipmentsPage.spec.ts
@@ -15,11 +15,11 @@ test('should create new sample collection', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'New Sample' })).toBeVisible({timeout: 10000});
 });
 
-test('should create new sample collection using existing samples', async ({ page }) => {
+test('should create new sample collection using existing grids', async ({ page }) => {
   await page.goto('/proposals/bi23047/sessions/100');
 
   await page.getByRole('textbox', { name: 'Name' }).fill("80");
-  const checkBox = page.getByLabel("Use Existing Samples");
+  const checkBox = page.getByLabel("Use Existing grids");
   const boundingBox = (await checkBox.boundingBox())!;
 
   // Move the cursor to centre of checkbox
@@ -27,7 +27,7 @@ test('should create new sample collection using existing samples', async ({ page
 
   await page.getByRole("button", {name: "Create"}).click();
   
-  await expect(page.getByRole('heading', { name: 'Import Existing Samples' })).toBeVisible({timeout: 10000});
+  await expect(page.getByRole('heading', { name: 'Import Existing Grids' })).toBeVisible({timeout: 10000});
 });
 
 test('should navigate to sample collection page when sample collection card clicked', async ({ page }) => {

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/pageContent.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/pageContent.tsx
@@ -19,13 +19,13 @@ const shipmentForm = [
     id: "name",
     label: "Name",
     type: "text",
-    hint: 'Use a descriptive name, that indicates what the samples will be used in. For example, "FIB"',
+    hint: 'Use a descriptive name, that indicates what the grids will be used in. For example, "FIB"',
     validation: { required: "Required" },
   },
   {
     id: "importSamples",
-    label: "Use Existing Samples",
-    hint: "Use samples from an existing sample collection, which is already stored in the facility",
+    label: "Use Existing Grids",
+    hint: "Use grids from an existing sample collection, which is already stored in the facility",
     type: "checkbox",
   },
 ] as DynamicFormEntry[];

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/page.tsx
@@ -4,7 +4,7 @@ import { Divider, Heading, Text, VStack } from "@chakra-ui/react";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Import Existing Samples - Scaup",
+  title: "Import Existing Grids - Scaup",
 };
 
 const SubmissionOverview = async (props: {
@@ -19,13 +19,13 @@ const SubmissionOverview = async (props: {
         <Heading size='md' color='gray.600'>
           {params.proposalId}-{params.visitNumber}
         </Heading>
-        <Heading>Import Existing Samples</Heading>
+        <Heading>Import Existing Grids</Heading>
         <Divider borderColor='gray.800' />
       </VStack>
       <VStack alignItems='start' w='100%' gap='1em'>
         <Text>
-          Import existing samples from other sample collections, for use in this sample collection.
-          Ensure your sample is already being stored at eBIC.
+          Import existing grids from other sample collections, for use in this sample collection.
+          Ensure your grid is already being stored at eBIC.
         </Text>
       </VStack>
       <ImportSamplesPageContent params={params} />

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.test.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.test.tsx
@@ -41,7 +41,7 @@ describe("Import Samples Page Content", () => {
     );
   });
 
-  it("should display message if no samples are available", async () => {
+  it("should display message if no grids are available", async () => {
     server.use(
       http.get(
         "http://localhost/api/proposals/:proposalReference/sessions/:visitNumber/samples",
@@ -55,7 +55,7 @@ describe("Import Samples Page Content", () => {
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "1" } });
     fireEvent.click(screen.getByText("Select"));
 
-    await screen.findByText("No samples available for transfer in this session.");
+    await screen.findByText("No grids available for transfer in this session.");
   });
 
   it("should disable checkbox if sample has already been imported", async () => {
@@ -101,7 +101,7 @@ describe("Import Samples Page Content", () => {
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "1" } });
     fireEvent.click(screen.getByText("Select"));
 
-    await screen.findByText("No samples available for transfer in this session.");
+    await screen.findByText("No grids available for transfer in this session.");
   });
 
   it("should redirect to pre-session page if 'Save and enter pre-session information' is clicked", async () => {

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.tsx
@@ -107,7 +107,7 @@ const ImportSamplesPageContent = ({ params }: { params: ShipmentParams }) => {
         </form>
       </FormProvider>
       <Heading size='lg' mt='1em' color={samples !== undefined ? undefined : "diamond.200"}>
-        Select Samples
+        Select Grids
       </Heading>
       {samples && samples.length > 0 ? (
         <VStack divider={<Divider borderColor='diamond.600' />} w='100%' mb='1em'>
@@ -125,7 +125,7 @@ const ImportSamplesPageContent = ({ params }: { params: ShipmentParams }) => {
                       {sample.name} <Tag colorScheme='purple'>{sample.parentShipmentName}</Tag>
                     </Heading>
                     <Text>{sample.comments}</Text>
-                    {hasChildren && <Text>Sample already imported</Text>}
+                    {hasChildren && <Text>Grid already imported</Text>}
                   </Checkbox>
                 );
               })}
@@ -135,7 +135,7 @@ const ImportSamplesPageContent = ({ params }: { params: ShipmentParams }) => {
       ) : (
         samples !== undefined && (
           <Heading variant='notFound' size='md'>
-            No samples available for transfer in this session.
+            No grids available for transfer in this session.
           </Heading>
         )
       )}

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.tsx
@@ -78,9 +78,9 @@ const ShipmentHome = async (props: { params: Promise<ShipmentParams> }) => {
     <VStack alignItems='start'>
       <VStack gap='0' alignItems='start' w='100%'>
         <Heading size='md' color='gray.600'>
-          Sample Collection
+          {shipmentData ? shipmentData.name : "Shipment"}
         </Heading>
-        <Heading>{shipmentData ? shipmentData.name : "Shipment"}</Heading>
+        <Heading>Sample Collection Summary</Heading>
         <Divider borderColor='gray.800' />
       </VStack>
       {shipmentData === null ? (
@@ -110,10 +110,10 @@ const ShipmentHome = async (props: { params: Promise<ShipmentParams> }) => {
           <HStack w='100%' mt='1em' alignItems='start' gap='3em' flexWrap='wrap'>
             <VStack alignItems='start' flex='1 0 600px'>
               <HStack w='100%'>
-                <Heading size='lg'>Samples</Heading>
+                <Heading size='lg'>Grids</Heading>
                 <Spacer />
                 <Button as={NextLink} href={`${params.shipmentId}/import-samples`} size='sm'>
-                  Import Samples from Session
+                  Import Grids from Session
                 </Button>
               </HStack>
               <Divider borderColor='gray.800' />
@@ -156,10 +156,7 @@ const ShipmentHome = async (props: { params: Promise<ShipmentParams> }) => {
                 title={`${shipmentData.preSessionInfo ? "Edit" : "Set"} Pre-Session Information`}
                 as={NextLink}
                 href={`${params.shipmentId}/pre-session`}
-                isDisabled={
-                  !shipmentData.preSessionInfo ||
-                  !!shipmentData.preSessionInfo.isLocked
-                }
+                isDisabled={!shipmentData.preSessionInfo || !!shipmentData.preSessionInfo.isLocked}
               >
                 Set imaging conditions, grid/data acquisition parameters
               </TwoLineLink>

--- a/src/components/containers/ChildSelector.test.tsx
+++ b/src/components/containers/ChildSelector.test.tsx
@@ -21,7 +21,7 @@ describe("Child Selector", () => {
       preloadedState: { shipment: { ...initialState, unassigned: defaultUnassigned } },
     });
 
-    expect(screen.getByText("Sample")).toBeInTheDocument();
+    expect(screen.getByText("Grid")).toBeInTheDocument();
   });
 
   it("should render selected item if passed", () => {
@@ -37,7 +37,7 @@ describe("Child Selector", () => {
       },
     );
 
-    expect(screen.getAllByText("Sample")).toHaveLength(2);
+    expect(screen.getAllByText("Grid")).toHaveLength(2);
   });
 
   it("should render message if no unassigned items are available", () => {
@@ -50,7 +50,7 @@ describe("Child Selector", () => {
       />,
     );
 
-    screen.getByText(/no unassigned samples/i);
+    screen.getByText(/no unassigned grids/i);
   });
 
   it("should fire event if item is selected", async () => {
@@ -128,7 +128,7 @@ describe("Child Selector", () => {
     expect(screen.queryByText(/remove/i)).not.toBeInTheDocument();
   });
 
-  it("should not render unassigned samples if in read only mode", () => {
+  it("should not render unassigned grids if in read only mode", () => {
     const itemClickCallback = vi.fn();
 
     renderWithProviders(
@@ -144,7 +144,7 @@ describe("Child Selector", () => {
       },
     );
 
-    expect(screen.queryByText("Sample")).not.toBeInTheDocument();
+    expect(screen.queryByText("Grid")).not.toBeInTheDocument();
   });
 
   it("should render selectable children if passed", () => {

--- a/src/components/containers/ChildSelector.tsx
+++ b/src/components/containers/ChildSelector.tsx
@@ -64,7 +64,7 @@ const ChildItemDetails = ({
       <Stat>
         <StatLabel>{childType}</StatLabel>
         <StatNumber>{childData.name}</StatNumber>
-        {childType === "Sample" && (
+        {childType === "Grid" && (
           <Grid w='100%' gap='0' templateColumns='repeat(2, 1fr)' mt='10px'>
             <ChildItemDetailsField
               label='Concentration'

--- a/src/components/containers/CrossShipmentSelector.test.tsx
+++ b/src/components/containers/CrossShipmentSelector.test.tsx
@@ -56,7 +56,7 @@ describe("Cross Sample Collection Child Selector", () => {
     expect(screen.getByText("puck")).toBeInTheDocument();
   });
 
-  it("should render message if selected session has no samples available", async () => {
+  it("should render message if selected session has no grids available", async () => {
     server.use(
       http.get(
         "http://localhost/api/proposals/:proposalId/sessions/:visitNumber/samples",
@@ -72,7 +72,7 @@ describe("Cross Sample Collection Child Selector", () => {
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "cm1234-5" } });
     fireEvent.click(screen.getByText("Select"));
 
-    await screen.findByText("No samples available for this session.");
+    await screen.findByText("No grids available for this session.");
   });
 
   it("should render selected item if passed", () => {

--- a/src/components/containers/GridBox.test.tsx
+++ b/src/components/containers/GridBox.test.tsx
@@ -68,7 +68,7 @@ describe("Grid Box", () => {
 
     fireEvent.click(screen.getByText("2"));
 
-    expect(screen.getByText(/select sample/i)).toBeInTheDocument();
+    expect(screen.getByText(/select grid/i)).toBeInTheDocument();
   });
 
   it("should pre-populate positions with data from state", () => {
@@ -79,12 +79,12 @@ describe("Grid Box", () => {
     expect(screen.getByTestId("1-populated")).toBeInTheDocument();
   });
 
-  it("should display message if no unassigned samples are available", () => {
+  it("should display message if no unassigned grids are available", () => {
     renderAndInjectForm(<GridBox parentId='1' />);
 
     fireEvent.click(screen.getByText("1"));
 
-    expect(screen.getByText(/no unassigned samples available/i));
+    expect(screen.getByText(/no unassigned grids available/i));
   });
 
   it("should fire location callback when apply clicked", async () => {

--- a/src/components/navigation/ItemStepper.test.tsx
+++ b/src/components/navigation/ItemStepper.test.tsx
@@ -26,7 +26,7 @@ describe("Item Stepper", () => {
   it("should render steps", () => {
     renderWithProviders(<ItemStepper steps={steps} onStepChanged={() => {}} currentStep={0} />);
 
-    expect(screen.getByLabelText("Samples Step")).toBeInTheDocument();
+    expect(screen.getByLabelText("Grids Step")).toBeInTheDocument();
     expect(screen.getByLabelText("Grid Boxes Step")).toBeInTheDocument();
     expect(screen.getByLabelText("Containers Step")).toBeInTheDocument();
     expect(screen.getByLabelText("Packages Step")).toBeInTheDocument();

--- a/src/components/navigation/SampleCard.test.tsx
+++ b/src/components/navigation/SampleCard.test.tsx
@@ -10,7 +10,7 @@ describe("Sample Card", () => {
     renderWithProviders(<SampleCard sample={baseSample} params={params} />);
 
     expect(screen.getByText("test-sample")).toBeInTheDocument();
-    expect(screen.getByText("View Sample")).toHaveAttribute(
+    expect(screen.getByText("View Grid")).toHaveAttribute(
       "href",
       "/proposals/cm00001/sessions/1/shipments/1/grid/1/review",
     );

--- a/src/components/navigation/SampleCard.tsx
+++ b/src/components/navigation/SampleCard.tsx
@@ -78,7 +78,7 @@ export const SampleCard = ({ sample, params }: SampleCardProps) => {
             as={NextLink}
             href={`${urlPrefix}${sample.shipmentId}/${sample.type}/${sample.id}/review`}
           >
-            View Sample
+            View Grid
           </Button>
         </HStack>
       </Stat>

--- a/src/features/shipment/shipmentSlice.ts
+++ b/src/features/shipment/shipmentSlice.ts
@@ -33,7 +33,7 @@ export const defaultUnassigned = [
     data: {},
     children: [
       {
-        name: "Samples",
+        name: "Grids",
         id: "sample",
         isUndeletable: true,
         isNotViewable: true,

--- a/src/mappings/pages.ts
+++ b/src/mappings/pages.ts
@@ -17,7 +17,7 @@ export interface Step {
 }
 
 export const steps: Step[] = [
-  { title: "Samples", id: ["sample", "grid"], singular: "Sample", endpoint: "samples" },
+  { title: "Grids", id: ["sample", "grid"], singular: "Grid", endpoint: "samples" },
   { title: "Grid Boxes", id: "gridBox", singular: "Grid Box", endpoint: "containers" },
   {
     title: "Containers",


### PR DESCRIPTION
**Summary**:

To reduce confusion with users, samples have been renamed to grids, to distinguish instances of samples from sample definitions.

**Changes**:
- Rename mentions of sample instances to grids

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions
- Create a new shipment and go through the whole process, all the way to the "submitted" page
- Check if mentions of "samples" or "sample" (not sample collections) have been replaced with "grids"
