### PR TITLE
Remove lid from grid box form, add c-clip direction

### DIFF
--- a/src/mappings/forms/gridBox.ts
+++ b/src/mappings/forms/gridBox.ts
@@ -27,12 +27,12 @@ export const gridBoxForm = [
     watch: true,
   },
   {
-    id: "lid",
-    label: "Lid",
+    id: "c-clip",
+    label: "C-Clip Direction",
     type: "dropdown",
     values: [
-      { label: "Screw", value: "Screw" },
-      { label: "Pin", value: "Pin" },
+      { label: "Anti-Clockwise", value: "Anti-Clockwise" },
+      { label: "Clockwise", value: "Clockwise" },
     ],
   },
   {
@@ -45,7 +45,6 @@ export const gridBoxForm = [
   {
     id: "comments",
     label: "Comments",
-    hint: "General comments, such as direction c-clip is facing respective to notch",
     type: "textarea",
   },
 ] as DynamicFormEntry[];


### PR DESCRIPTION
**Summary**:

Since eBIC already has tools for both types of lid, asking users which lid they're using for the grid box is essentially useless. Instead, it would be more useful to know the c-clip direction on the grids.

**Changes**:
- Remove lid from grid box form, add c-clip direction

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/gridBox/new/edit, check if the form has a "C-Clip Direction" field
 
<img width="595" height="469" alt="image" src="https://github.com/user-attachments/assets/bb54f04d-70d8-4612-8670-a09b4a3fefe7" />

