### PR TITLE
[LIMS-1850] Display grid information in cassette slots

### DIFF
--- a/src/components/containers/Cassette.tsx
+++ b/src/components/containers/Cassette.tsx
@@ -33,7 +33,7 @@ export const Cassette = ({ samples }: CassetteProps) => {
     () =>
       samples.reduce((selectable, sample) => {
         if (sample.subLocation === null) {
-          selectable.push({ id: sample.id, name: sample.name || "", data: {} });
+          selectable.push({ id: sample.id, name: sample.name || "", data: sample.details });
         }
         return selectable;
       }, [] as TreeData[]),


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1850](https://jira.diamond.ac.uk/browse/LIMS-1850)

**Summary**:

Previously, grid information wasn't passed to the right components, which meant that it wouldn't get displayed when populating cassettes. This is now passed correctly.

**Changes**:
- Display grid information in cassette slots

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118, click any cassette slot, check if grid information (buffer, concentration...) is displayed as follows:
<img width="706" height="495" alt="image" src="https://github.com/user-attachments/assets/c0acc336-d7d3-47f7-b7e6-854b5a52450c" />

