### PR TITLE
[LIMS-1910] Update c-clip direction descriptions

### DIFF
--- a/src/mappings/forms/gridBox.ts
+++ b/src/mappings/forms/gridBox.ts
@@ -31,8 +31,14 @@ export const gridBoxForm = [
     label: "C-Clip Direction",
     type: "dropdown",
     values: [
-      { label: "Anti-Clockwise", value: "Anti-Clockwise" },
-      { label: "Clockwise", value: "Clockwise" },
+      {
+        label: "Anti-Clockwise (facing left with respect to notch)",
+        value: "Anti-Clockwise (facing left with respect to notch)",
+      },
+      {
+        label: "Clockwise (facing right with respect to notch)",
+        value: "Clockwise (facing right with respect to notch)",
+      },
     ],
   },
   {


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1910](https://jira.diamond.ac.uk/browse/LIMS-1910)

**Summary**:

Users were getting confused when selecting c-clip direction for their grids, this adds further clarification to prevent confusion

**Changes**:
- Update c-clip direction descriptions

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/gridBox/new/edit, check if c-clip directions look like the following

 
<img width="767" height="150" alt="image" src="https://github.com/user-attachments/assets/56a075b5-82bd-40b5-8dde-489ebe91c6e5" />

