### PR TITLE
[LIMS-1937] Push samples to ISPyB when importing from a different session

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.tsx
@@ -83,11 +83,13 @@ const ImportSamplesPageContent = ({ params }: { params: ShipmentParams }) => {
                 parents: [samples[parseInt(i)].id],
               },
               "samples",
+              "shipment",
+              new URLSearchParams({includeSuffix: "false", pushToExternalDb: "true"})
             ),
           ),
         );
 
-        router.push("pre-session");
+        router.push("pre-session?skipPush=true");
       } catch {
         toast({ title: "Could not update items, please try again later", status: "error" });
       } finally {

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/import-samples/pageContent.tsx
@@ -84,7 +84,7 @@ const ImportSamplesPageContent = ({ params }: { params: ShipmentParams }) => {
               },
               "samples",
               "shipment",
-              new URLSearchParams({includeSuffix: "false", pushToExternalDb: "true"})
+              new URLSearchParams({ includeSuffix: "false", pushToExternalDb: "true" }),
             ),
           ),
         );

--- a/src/utils/client/item.ts
+++ b/src/utils/client/item.ts
@@ -59,10 +59,13 @@ export class Item {
     data: Record<string, any>,
     endpoint: Step["endpoint"],
     parentType: RootParentType = "shipment",
+    searchParams?: URLSearchParams
   ): Promise<CreationResponse | CreationResponse[]> {
     const parentEndpoint = parentTypeToEndpoint[parentType];
+    const searchParamText = searchParams ? "?" + searchParams.toString() : "";
+
     return await genericCreateItem(
-      `/${parentEndpoint}${parentType === "shipment" && parentId ? `/${parentId}` : ""}/${endpoint}`,
+      `/${parentEndpoint}${parentType === "shipment" && parentId ? `/${parentId}` : ""}/${endpoint}${searchParamText}`,
       data,
     );
   }

--- a/src/utils/client/item.ts
+++ b/src/utils/client/item.ts
@@ -59,7 +59,7 @@ export class Item {
     data: Record<string, any>,
     endpoint: Step["endpoint"],
     parentType: RootParentType = "shipment",
-    searchParams?: URLSearchParams
+    searchParams?: URLSearchParams,
   ): Promise<CreationResponse | CreationResponse[]> {
     const parentEndpoint = parentTypeToEndpoint[parentType];
     const searchParamText = searchParams ? "?" + searchParams.toString() : "";


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1937](https://jira.diamond.ac.uk/browse/LIMS-1937)

Requires https://github.com/DiamondLightSource/scaup-backend/pull/17

**Summary**:

This pushes samples to ISPyB automatically when they're imported from a different session. It also tells SCAUP's backend not to add any suffixes to the name

**Changes**:
- [Push samples to ISPyB when importing from a different session](https://github.com/DiamondLightSource/scaup-frontend/commit/3fe2aaec046662076d06637417afd66256b31978)

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100, tick "Use Existing Grids", select 100 as the session
- Select the two unselected grids
- Fill in the pre-session information
- Submit and finish
- Check if the BLSample table in ISPyB contains the samples you just added
