### PR TITLE
[LIMS-1879] Proposal sample collections page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,7 @@ const nextConfig = {
       },
       {
         source: "/proposals/:proposalId",
-        destination: "/proposals/:proposalId/sessions",
+        destination: "/proposals/:proposalId/shipments",
         permanent: true,
       },
       {

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,11 +1,17 @@
 import HomePage from "@/app/page";
-import { renderWithProviders } from "@/utils/test-utils";
-import { screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 describe("Home Page", () => {
   it("should render page", async () => {
-    renderWithProviders(<HomePage />);
+    render(await HomePage());
 
     expect(screen.getByText("Proposals")).toBeInTheDocument();
+  });
+
+  it("should display number of sample collections for sessions", async () => {
+    render(await HomePage());
+
+    expect(screen.getAllByText(/sample collections:/i)).toHaveLength(2);
+    expect(screen.getAllByText("2")).toHaveLength(2);
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -145,7 +145,7 @@ const Home = async () => {
               borderRadius={5}
             >
               <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
-                {item.session.beamLineOperator ? item.session.beamLineOperator.join(",") : "?"}
+                {item.session.beamLineOperator ? item.session.beamLineOperator.join(", ") : "?"}
               </StatLabel>
               <StatNumber>
                 {item.session.parentProposal}-{item.session.visitNumber ?? "?"}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,8 +64,6 @@ const getSessions = async () => {
     `/sessions?limit=4&minEndDate=${currentDate.toISOString()}`,
   );
 
-  return null;
-
   if (response.status !== 200) {
     return null;
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,23 @@
-import { Link, Heading, HStack, Text, VStack, Box, Stat, StatHelpText, StatLabel, StatNumber, Divider } from "@chakra-ui/react";
+import { components } from "@/types/schema";
+import { authenticatedFetch } from "@/utils/client";
+import { formatDate } from "@/utils/generic";
+import {
+  Link,
+  Heading,
+  HStack,
+  Text,
+  VStack,
+  Box,
+  Stat,
+  StatHelpText,
+  StatLabel,
+  StatNumber,
+  Divider,
+  Button,
+} from "@chakra-ui/react";
 import { Metadata } from "next/types";
 import { MdArrowForward } from "react-icons/md";
+import NextLink from "next/link";
 
 export const metadata: Metadata = {
   title: "SCAUP",
@@ -15,15 +32,15 @@ interface InfoBoxProps {
 const InfoBox = ({ title, children, href }: InfoBoxProps) => (
   <Box
     flex='1 0 0'
-    minW="300px"
+    minW='300px'
     as={Link}
     href={href}
     alignItems='start'
     p='1em'
     position='relative'
     color='diamond.500'
-    borderColor="diamond.500"
-    border="1px solid"
+    borderColor='diamond.500'
+    border='1px solid'
     _hover={{ backgroundColor: "diamond.700" }}
   >
     <VStack alignItems='start'>
@@ -41,174 +58,140 @@ const InfoBox = ({ title, children, href }: InfoBoxProps) => (
   </Box>
 );
 
-const Home = () => (
-  <main>
-    <Box
-      bg='diamond.700'
-      alignItems='start'
-      color='diamond.50'
-      bgImage='/hall.png'
-      bgPosition='center'
-      bgRepeat='no-repeat'
-      bgSize='cover'
-      mx='-7.3vw'
-      borderBottom='10px solid var(--chakra-colors-diamond-500)'
-    >
-      <HStack
-          bg='rgba(0, 5, 77, 0.7)'
-          px='5vw'
-          backdropFilter='blur(5px)'
-          py='15vh'>
-        <VStack
-        flex="1 0 0"
-          alignItems='start'
-        >
-          <Heading>SCAUP</Heading>
-          <Heading size='md' fontWeight='200'>
-            Sample consignment and user experiment parametrisation
-          </Heading>
-        </VStack>
-        <HStack>
-        <InfoBox title='Proposals' href={`${process.env.PATO_URL}/proposals`}>
-          View list of proposals
-        </InfoBox>
-        <InfoBox title='User Guide' href={process.env.USER_GUIDE_URL!}>
-          Open detailed user guide
-        </InfoBox></HStack>
-      </HStack>
-    </Box>
-    <Heading textAlign='left' w='100%' size='lg' mt="1em">
-      Current Proposals
-    </Heading>
-    <Divider borderColor='diamond.300' />
-    <HStack mt='1em'>
+const getSessions = async () => {
+  const currentDate = new Date();
+  const response = await authenticatedFetch.server(
+    `/sessions?limit=4&minEndDate=${currentDate.toISOString()}`,
+  );
+
+  return null;
+
+  if (response.status !== 200) {
+    return null;
+  }
+
+  const sessions: components["schemas"]["Paged_SessionOut_"] = await response.json();
+  return await Promise.all(
+    sessions.items.map(async (session) => {
+      if (session.visitNumber === undefined) {
+        return { session, shipmentCount: 0 };
+      }
+
+      const response = await authenticatedFetch.server(
+        `/proposals/${session.parentProposal}/sessions/${session.visitNumber}/shipments?limit=1`,
+      );
+
+      if (response.status !== 200) {
+        return { session, shipmentCount: 0 };
+      }
+
+      const shipmentsResponse: components["schemas"]["Paged_ShipmentOut_"] = await response.json();
+
+      return { session, shipmentCount: shipmentsResponse.total };
+    }),
+  );
+};
+
+const Home = async () => {
+  const sessions = await getSessions();
+
+  return (
+    <main>
+      <Box
+        bg='diamond.700'
+        alignItems='start'
+        color='diamond.50'
+        bgImage='/hall.png'
+        bgPosition='center'
+        bgRepeat='no-repeat'
+        bgSize='cover'
+        mx='-7.3vw'
+        borderBottom='10px solid var(--chakra-colors-diamond-500)'
+      >
+        <HStack bg='rgba(0, 5, 77, 0.7)' px='5vw' backdropFilter='blur(5px)' py='15vh'>
+          <VStack flex='1 0 0' alignItems='start'>
+            <Heading>SCAUP</Heading>
+            <Heading size='md' fontWeight='200'>
+              <b>S</b>ample <b>C</b>onsignment <b>A</b>nd <b>U</b>ser experiment <b>P</b>
+              arametrisation
+            </Heading>
+          </VStack>
+          <HStack>
+            <InfoBox title='Proposals' href={`${process.env.PATO_URL}/proposals`}>
+              View list of proposals
+            </InfoBox>
+            <InfoBox title='User Guide' href={process.env.USER_GUIDE_URL!}>
+              Open detailed user guide
+            </InfoBox>
+          </HStack>
+        </HStack>
+      </Box>
+      <Heading textAlign='left' w='100%' size='lg' mt='1em'>
+        Current Sessions
+      </Heading>
+      <Divider borderColor='diamond.300' />
+      <HStack my='1em' flexWrap='wrap'>
+        {sessions ? (
+          sessions.map((item) => (
             <Stat
+              key={item.session.sessionId}
               _hover={{
                 borderColor: "diamond.400",
               }}
               bg='diamond.50'
               overflow='hidden'
-              w='calc(100%)'
               p={2}
+              flex='1 0 0'
+              minW='180px'
               border='1px solid grey'
               borderRadius={5}
             >
               <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
-                Krios I - Dr. Test
+                {item.session.beamLineOperator ? item.session.beamLineOperator.join(",") : "?"}
               </StatLabel>
               <StatNumber>
-                bi23047
+                {item.session.parentProposal}-{item.session.visitNumber ?? "?"}
               </StatNumber>
               <StatHelpText mb='0'>
                 <b>Start: </b>
-                2025-01-01 11:11:11
+                {formatDate(item.session.startDate)}
               </StatHelpText>
               <StatHelpText mb='0'>
                 <b>End: </b>
-                2025-01-01 11:11:11
+                {formatDate(item.session.endDate)}
               </StatHelpText>
-            </Stat><Stat
-              _hover={{
-                borderColor: "diamond.400",
-              }}
-              bg='diamond.50'
-              overflow='hidden'
-              w='calc(100%)'
-              p={2}
-              border='1px solid grey'
-              borderRadius={5}
-            >
-              <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
-                Krios I - Dr. Test
-              </StatLabel>
-              <StatNumber>
-                bi23047
-              </StatNumber>
-              <StatHelpText mb='0'>
-                <b>Start: </b>
-                2025-01-01 11:11:11
+              <StatHelpText>
+                <b>Sample Collections: </b>
+                {item.shipmentCount}
               </StatHelpText>
-              <StatHelpText mb='0'>
-                <b>End: </b>
-                2025-01-01 11:11:11
-              </StatHelpText>
-            </Stat><Stat
-              _hover={{
-                borderColor: "diamond.400",
-              }}
-              bg='diamond.50'
-              overflow='hidden'
-              w='calc(100%)'
-              p={2}
-              border='1px solid grey'
-              borderRadius={5}
-            >
-              <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
-                Krios I - Dr. Test
-              </StatLabel>
-              <StatNumber>
-                bi23047
-              </StatNumber>
-              <StatHelpText mb='0'>
-                <b>Start: </b>
-                2025-01-01 11:11:11
-              </StatHelpText>
-              <StatHelpText mb='0'>
-                <b>End: </b>
-                2025-01-01 11:11:11
-              </StatHelpText>
-            </Stat><Stat
-              _hover={{
-                borderColor: "diamond.400",
-              }}
-              bg='diamond.50'
-              overflow='hidden'
-              w='calc(100%)'
-              p={2}
-              border='1px solid grey'
-              borderRadius={5}
-            >
-              <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
-                Krios I - Dr. Test
-              </StatLabel>
-              <StatNumber>
-                bi23047
-              </StatNumber>
-              <StatHelpText mb='0'>
-                <b>Start: </b>
-                2025-01-01 11:11:11
-              </StatHelpText>
-              <StatHelpText mb='0'>
-                <b>End: </b>
-                2025-01-01 11:11:11
-              </StatHelpText>
-            </Stat><Stat
-              _hover={{
-                borderColor: "diamond.400",
-              }}
-              bg='diamond.50'
-              overflow='hidden'
-              w='calc(100%)'
-              p={2}
-              border='1px solid grey'
-              borderRadius={5}
-            >
-              <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
-                Krios I - Dr. Test
-              </StatLabel>
-              <StatNumber>
-                bi23047
-              </StatNumber>
-              <StatHelpText mb='0'>
-                <b>Start: </b>
-                2025-01-01 11:11:11
-              </StatHelpText>
-              <StatHelpText mb='0'>
-                <b>End: </b>
-                2025-01-01 11:11:11
-              </StatHelpText>
-            </Stat></HStack>
-  </main>
-);
+              <HStack flexWrap='wrap'>
+                <Button
+                  size='xs'
+                  minW='160px'
+                  flex='1 0 0'
+                  href={`/proposals/${item.session.parentProposal}/sessions/${item.session.visitNumber}/shipments`}
+                  as={NextLink}
+                >
+                  View session overview
+                </Button>
+                <Button
+                  size='xs'
+                  minW='160px'
+                  flex='1 0 0'
+                  href={`/proposals/${item.session.parentProposal}/shipments`}
+                  as={NextLink}
+                >
+                  View proposal overview
+                </Button>
+              </HStack>
+            </Stat>
+          ))
+        ) : (
+          <Heading variant='notFound' w="100%">No sessions available</Heading>
+        )}
+      </HStack>
+    </main>
+  );
+};
 
 export default Home;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { Link, Heading, HStack, Text, VStack, Box } from "@chakra-ui/react";
+import { Link, Heading, HStack, Text, VStack, Box, Stat, StatHelpText, StatLabel, StatNumber, Divider } from "@chakra-ui/react";
 import { Metadata } from "next/types";
 import { MdArrowForward } from "react-icons/md";
 
@@ -15,13 +15,15 @@ interface InfoBoxProps {
 const InfoBox = ({ title, children, href }: InfoBoxProps) => (
   <Box
     flex='1 0 0'
+    minW="300px"
     as={Link}
     href={href}
     alignItems='start'
-    bg='diamond.600'
     p='1em'
     position='relative'
-    color='diamond.50'
+    color='diamond.500'
+    borderColor="diamond.500"
+    border="1px solid"
     _hover={{ backgroundColor: "diamond.700" }}
   >
     <VStack alignItems='start'>
@@ -52,30 +54,160 @@ const Home = () => (
       mx='-7.3vw'
       borderBottom='10px solid var(--chakra-colors-diamond-500)'
     >
-      <VStack
-        px='10vw'
-        py='20vh'
-        backdropFilter='blur(5px)'
-        alignItems='start'
-        bg='rgba(0, 5, 77, 0.7)'
-      >
-        <Heading>SCAUP</Heading>
-        <Heading size='md' fontWeight='200'>
-          Sample registration, shipping and experiment parametrisation
-        </Heading>
-      </VStack>
+      <HStack
+          bg='rgba(0, 5, 77, 0.7)'
+          px='5vw'
+          backdropFilter='blur(5px)'
+          py='15vh'>
+        <VStack
+        flex="1 0 0"
+          alignItems='start'
+        >
+          <Heading>SCAUP</Heading>
+          <Heading size='md' fontWeight='200'>
+            Sample consignment and user experiment parametrisation
+          </Heading>
+        </VStack>
+        <HStack>
+        <InfoBox title='Proposals' href={`${process.env.PATO_URL}/proposals`}>
+          View list of proposals
+        </InfoBox>
+        <InfoBox title='User Guide' href={process.env.USER_GUIDE_URL!}>
+          Open detailed user guide
+        </InfoBox></HStack>
+      </HStack>
     </Box>
+    <Heading textAlign='left' w='100%' size='lg' mt="1em">
+      Current Proposals
+    </Heading>
+    <Divider borderColor='diamond.300' />
     <HStack mt='1em'>
-      <InfoBox title='Proposals' href={`${process.env.PATO_URL}/proposals`}>
-        View list of proposals
-      </InfoBox>
-      <InfoBox title='User Guide' href={process.env.USER_GUIDE_URL!}>
-        Open detailed user guide
-      </InfoBox>
-      <InfoBox title='API Definition' href={`${process.env.NEXT_PUBLIC_API_URL}/docs`}>
-        View API documentation
-      </InfoBox>
-    </HStack>
+            <Stat
+              _hover={{
+                borderColor: "diamond.400",
+              }}
+              bg='diamond.50'
+              overflow='hidden'
+              w='calc(100%)'
+              p={2}
+              border='1px solid grey'
+              borderRadius={5}
+            >
+              <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
+                Krios I - Dr. Test
+              </StatLabel>
+              <StatNumber>
+                bi23047
+              </StatNumber>
+              <StatHelpText mb='0'>
+                <b>Start: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+              <StatHelpText mb='0'>
+                <b>End: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+            </Stat><Stat
+              _hover={{
+                borderColor: "diamond.400",
+              }}
+              bg='diamond.50'
+              overflow='hidden'
+              w='calc(100%)'
+              p={2}
+              border='1px solid grey'
+              borderRadius={5}
+            >
+              <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
+                Krios I - Dr. Test
+              </StatLabel>
+              <StatNumber>
+                bi23047
+              </StatNumber>
+              <StatHelpText mb='0'>
+                <b>Start: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+              <StatHelpText mb='0'>
+                <b>End: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+            </Stat><Stat
+              _hover={{
+                borderColor: "diamond.400",
+              }}
+              bg='diamond.50'
+              overflow='hidden'
+              w='calc(100%)'
+              p={2}
+              border='1px solid grey'
+              borderRadius={5}
+            >
+              <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
+                Krios I - Dr. Test
+              </StatLabel>
+              <StatNumber>
+                bi23047
+              </StatNumber>
+              <StatHelpText mb='0'>
+                <b>Start: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+              <StatHelpText mb='0'>
+                <b>End: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+            </Stat><Stat
+              _hover={{
+                borderColor: "diamond.400",
+              }}
+              bg='diamond.50'
+              overflow='hidden'
+              w='calc(100%)'
+              p={2}
+              border='1px solid grey'
+              borderRadius={5}
+            >
+              <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
+                Krios I - Dr. Test
+              </StatLabel>
+              <StatNumber>
+                bi23047
+              </StatNumber>
+              <StatHelpText mb='0'>
+                <b>Start: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+              <StatHelpText mb='0'>
+                <b>End: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+            </Stat><Stat
+              _hover={{
+                borderColor: "diamond.400",
+              }}
+              bg='diamond.50'
+              overflow='hidden'
+              w='calc(100%)'
+              p={2}
+              border='1px solid grey'
+              borderRadius={5}
+            >
+              <StatLabel whiteSpace='nowrap' textOverflow='ellipsis' overflow='hidden'>
+                Krios I - Dr. Test
+              </StatLabel>
+              <StatNumber>
+                bi23047
+              </StatNumber>
+              <StatHelpText mb='0'>
+                <b>Start: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+              <StatHelpText mb='0'>
+                <b>End: </b>
+                2025-01-01 11:11:11
+              </StatHelpText>
+            </Stat></HStack>
   </main>
 );
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -185,7 +185,9 @@ const Home = async () => {
             </Stat>
           ))
         ) : (
-          <Heading variant='notFound' w="100%">No sessions available</Heading>
+          <Heading variant='notFound' w='100%'>
+            No sessions available
+          </Heading>
         )}
       </HStack>
     </main>

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/page.tsx
@@ -1,4 +1,5 @@
 import { ShipmentCreationForm } from "@/app/proposals/[proposalId]/sessions/[visitNumber]/pageContent";
+import { getShipmentStatus } from "@/mappings/colours";
 import { SessionParams } from "@/types/generic";
 import { components } from "@/types/schema";
 import { authenticatedFetch } from "@/utils/client";
@@ -21,18 +22,6 @@ export const metadata: Metadata = {
   title: "Session - Scaup",
 };
 
-const VALID_SHIPMENT_STATUSES: Record<string, string> = {
-  "at facility": "green",
-  "awb created": "purple",
-  "dispatch-requested": "purple",
-  opened: "green",
-  "pickup booked": "purple",
-  "pickup cancelled": "red",
-  processing: "green",
-  "sent to facility": "green",
-  "transfer-requested": "purple",
-};
-
 const getShipments = async (proposalId: string, visitNumber: string) => {
   const res = await authenticatedFetch.server(
     `/proposals/${proposalId}/sessions/${visitNumber}/shipments`,
@@ -44,21 +33,6 @@ const getShipments = async (proposalId: string, visitNumber: string) => {
   }
 
   return null;
-};
-
-const getShipmentStatus = (shipment: components["schemas"]["ShipmentOut"]) => {
-  if (shipment.status === null || shipment.status === undefined) {
-    const creationStatus = shipment.externalId ? "Submitted" : "Draft";
-    return {
-      colour: creationStatus === "Submitted" ? "green" : "gray",
-      statusText: creationStatus,
-    };
-  }
-
-  return {
-    colour: VALID_SHIPMENT_STATUSES[shipment.status] || "gray",
-    statusText: shipment.status,
-  };
 };
 
 const SessionOverview = async (props: { params: Promise<SessionParams> }) => {

--- a/src/app/proposals/[proposalId]/sessions/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/page.tsx
@@ -1,8 +1,92 @@
-import { redirect } from "next/navigation";
+import { ShipmentCard } from "@/components/navigation/ShipmentCard";
+import { getShipmentStatus } from "@/mappings/colours";
+import { components } from "@/types/schema";
+import { authenticatedFetch } from "@/utils/client";
+import { formatDate } from "@/utils/generic";
+import { Divider, Heading, HStack, Tag, VStack } from "@chakra-ui/react";
+import { Pagination, Table, TwoLineLink } from "@diamondlightsource/ui-components";
+import Link from "next/link";
 
-const ProposalRedirect = async (props: { params: Promise<{ proposalId: string }> }) => {
-  const params = await props.params;
-  redirect(`${process.env.PATO_URL}/proposals/${params.proposalId}/sessions`);
+const getProposalShipments = async (proposalReference: string) => {
+  const res = await authenticatedFetch.server(`/proposals/${proposalReference}/shipments`);
+
+  if (res && res.status === 200) {
+    const shipments: components["schemas"]["Paged_ShipmentOut_"] = await res.json();
+    return {
+      ...shipments,
+      items: shipments.items.map((shipment) => ({
+        ...shipment,
+        visitNumber: (
+          <Link color='diamond.600' href=''>
+            {shipment.visitNumber}
+          </Link>
+        ),
+        creationDate: shipment.creationDate ? formatDate(shipment.creationDate) : "Unknown",
+        status: (
+          <Tag colorScheme={getShipmentStatus(shipment).colour}>
+            {getShipmentStatus(shipment).statusText}
+          </Tag>
+        ),
+      })),
+    };
+  }
+
+  return null;
 };
 
-export default ProposalRedirect;
+const ProposalPage = async (props: { params: Promise<{ proposalId: string }> }) => {
+  const { proposalId } = await props.params;
+  const shipments = await getProposalShipments(proposalId);
+
+  return (
+    <VStack w='100%'>
+      <VStack w='100%' gap='0' alignItems='start'>
+        <Heading size='md' color='gray.600'>
+          {proposalId}
+        </Heading>
+        <Heading>Proposal Sample Collections</Heading>
+        <Divider borderColor='gray.800' />
+      </VStack>
+      <HStack w='100%' alignItems='start' gap='2em'>
+        {/*{shipments ? (
+          <VStack flex='1 0 0'>
+            {shipments.map((shipment) => (
+              <ShipmentCard key={shipment.id} shipment={shipment} />
+            ))}
+          </VStack>
+        ) : (
+          <p>Test</p>
+        )}*/}
+        <VStack flex='1 0 0' alignItems='start'>
+          <Heading size='lg'>Shipments</Heading>
+          <Divider />
+          {shipments && shipments.items && (
+            <Table
+              w='100%'
+              data={shipments.items}
+              headers={[
+                { key: "visitNumber", label: "Session" },
+                { key: "name", label: "Name" },
+                { key: "status", label: "Status" },
+                { key: "creationDate", label: "Creation Date" },
+                { key: "comments", label: "Comments" },
+              ]}
+            />
+          )}
+        </VStack>
+        <VStack alignItems='start' flexBasis='400px'>
+          <Heading size='lg'>Actions</Heading>
+          <Divider />
+          <TwoLineLink
+            title='View sessions in PATo'
+            href={`${process.env.PATO_URL}/proposals/${proposalId}`}
+          >
+            View session list in PATo
+          </TwoLineLink>
+        </VStack>
+      </HStack>
+    </VStack>
+  );
+};
+
+export default ProposalPage;

--- a/src/app/proposals/[proposalId]/shipments/page.test.tsx
+++ b/src/app/proposals/[proposalId]/shipments/page.test.tsx
@@ -1,0 +1,45 @@
+import ProposalShipmentsPage from "@/app/proposals/[proposalId]/shipments/page";
+import { server } from "@/mocks/server";
+import { baseSessionParams } from "@/utils/test-utils";
+import { render, screen } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+
+const baseShipment = { proposalReference: "cm00001" };
+
+describe("Proposal Sample Collections", () => {
+  it("should display proposal sample collections", async () => {
+    
+
+    render(await ProposalShipmentsPage(baseSessionParams));
+
+    expect(screen.getByText("Session: 1")).toBeInTheDocument();
+  });
+
+  it("should display message if there are no sample collections in this proposal", async () => {
+    server.use(
+      http.get(
+        "http://localhost/api/proposals/:proposalReference/shipments",
+        () => HttpResponse.json({items: []}, { status: 200 }),
+      ),
+    );
+
+    render(await ProposalShipmentsPage(baseSessionParams));
+
+    expect(
+      screen.getByText("This session has no sample collections assigned to it yet. You can:"),
+    ).toBeInTheDocument();
+  });
+
+  it("should display message if request fails", async () => {
+    server.use(
+      http.get(
+        "http://localhost/api/proposals/:proposalReference/shipments",
+        () => HttpResponse.json({}, { status: 404 }),
+      ),
+    );
+
+    render(await ProposalShipmentsPage(baseSessionParams));
+
+    expect(screen.getByText("cm1234-1")).toBeInTheDocument();
+  });
+});

--- a/src/app/proposals/[proposalId]/shipments/page.test.tsx
+++ b/src/app/proposals/[proposalId]/shipments/page.test.tsx
@@ -8,38 +8,32 @@ const baseShipment = { proposalReference: "cm00001" };
 
 describe("Proposal Sample Collections", () => {
   it("should display proposal sample collections", async () => {
-    
-
     render(await ProposalShipmentsPage(baseSessionParams));
 
-    expect(screen.getByText("Session: 1")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
   });
 
   it("should display message if there are no sample collections in this proposal", async () => {
     server.use(
-      http.get(
-        "http://localhost/api/proposals/:proposalReference/shipments",
-        () => HttpResponse.json({items: []}, { status: 200 }),
+      http.get("http://localhost/api/proposals/:proposalReference/shipments", () =>
+        HttpResponse.json({ items: [] }, { status: 200 }),
       ),
     );
 
     render(await ProposalShipmentsPage(baseSessionParams));
 
-    expect(
-      screen.getByText("This session has no sample collections assigned to it yet. You can:"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("No shipments found")).toBeInTheDocument();
   });
 
   it("should display message if request fails", async () => {
     server.use(
-      http.get(
-        "http://localhost/api/proposals/:proposalReference/shipments",
-        () => HttpResponse.json({}, { status: 404 }),
+      http.get("http://localhost/api/proposals/:proposalReference/shipments", () =>
+        HttpResponse.json({}, { status: 404 }),
       ),
     );
 
     render(await ProposalShipmentsPage(baseSessionParams));
 
-    expect(screen.getByText("cm1234-1")).toBeInTheDocument();
+    expect(screen.getByText("No shipments found")).toBeInTheDocument();
   });
 });

--- a/src/app/proposals/[proposalId]/shipments/page.tsx
+++ b/src/app/proposals/[proposalId]/shipments/page.tsx
@@ -3,9 +3,14 @@ import { getShipmentStatus } from "@/mappings/colours";
 import { components } from "@/types/schema";
 import { authenticatedFetch } from "@/utils/client";
 import { formatDate } from "@/utils/generic";
-import { Divider, Heading, HStack, Tag, VStack } from "@chakra-ui/react";
+import { Divider, Heading, HStack, Text, VStack } from "@chakra-ui/react";
 import { Pagination, Table, TwoLineLink } from "@diamondlightsource/ui-components";
+import { Metadata } from "next";
 import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Proposal Sample Collections - SCAUP",
+};
 
 const getProposalShipments = async (proposalReference: string) => {
   const res = await authenticatedFetch.server(`/proposals/${proposalReference}/shipments`);
@@ -16,17 +21,7 @@ const getProposalShipments = async (proposalReference: string) => {
       ...shipments,
       items: shipments.items.map((shipment) => ({
         ...shipment,
-        visitNumber: (
-          <Link color='diamond.600' href=''>
-            {shipment.visitNumber}
-          </Link>
-        ),
         creationDate: shipment.creationDate ? formatDate(shipment.creationDate) : "Unknown",
-        status: (
-          <Tag colorScheme={getShipmentStatus(shipment).colour}>
-            {getShipmentStatus(shipment).statusText}
-          </Tag>
-        ),
       })),
     };
   }
@@ -34,7 +29,7 @@ const getProposalShipments = async (proposalReference: string) => {
   return null;
 };
 
-const ProposalPage = async (props: { params: Promise<{ proposalId: string }> }) => {
+const ProposalShipmentsPage = async (props: { params: Promise<{ proposalId: string }> }) => {
   const { proposalId } = await props.params;
   const shipments = await getProposalShipments(proposalId);
 
@@ -49,29 +44,21 @@ const ProposalPage = async (props: { params: Promise<{ proposalId: string }> }) 
       </VStack>
       <HStack w='100%' alignItems='start' gap='2em'>
         {/*{shipments ? (
-          <VStack flex='1 0 0'>
-            {shipments.map((shipment) => (
-              <ShipmentCard key={shipment.id} shipment={shipment} />
-            ))}
-          </VStack>
+          
         ) : (
           <p>Test</p>
         )}*/}
         <VStack flex='1 0 0' alignItems='start'>
           <Heading size='lg'>Shipments</Heading>
           <Divider />
-          {shipments && shipments.items && (
-            <Table
-              w='100%'
-              data={shipments.items}
-              headers={[
-                { key: "visitNumber", label: "Session" },
-                { key: "name", label: "Name" },
-                { key: "status", label: "Status" },
-                { key: "creationDate", label: "Creation Date" },
-                { key: "comments", label: "Comments" },
-              ]}
-            />
+          {shipments && shipments.items ? (
+            <VStack flex='1 0 0' w='100%'>
+              {shipments.items.map((shipment) => (
+                <ShipmentCard key={shipment.id} shipment={shipment} />
+              ))}
+            </VStack>
+          ) : (
+            <Text>No shipments found</Text>
           )}
         </VStack>
         <VStack alignItems='start' flexBasis='400px'>
@@ -89,4 +76,4 @@ const ProposalPage = async (props: { params: Promise<{ proposalId: string }> }) 
   );
 };
 
-export default ProposalPage;
+export default ProposalShipmentsPage;

--- a/src/app/proposals/[proposalId]/shipments/page.tsx
+++ b/src/app/proposals/[proposalId]/shipments/page.tsx
@@ -43,22 +43,17 @@ const ProposalShipmentsPage = async (props: { params: Promise<{ proposalId: stri
         <Divider borderColor='gray.800' />
       </VStack>
       <HStack w='100%' alignItems='start' gap='2em'>
-        {/*{shipments ? (
-          
-        ) : (
-          <p>Test</p>
-        )}*/}
         <VStack flex='1 0 0' alignItems='start'>
           <Heading size='lg'>Shipments</Heading>
           <Divider />
-          {shipments && shipments.items ? (
+          {shipments && shipments.items && shipments.items.length > 0 ? (
             <VStack flex='1 0 0' w='100%'>
               {shipments.items.map((shipment) => (
                 <ShipmentCard key={shipment.id} shipment={shipment} />
               ))}
             </VStack>
           ) : (
-            <Text>No shipments found</Text>
+            <Heading variant="notFound" size="md">No shipments found</Heading>
           )}
         </VStack>
         <VStack alignItems='start' flexBasis='400px'>

--- a/src/app/proposals/[proposalId]/shipments/page.tsx
+++ b/src/app/proposals/[proposalId]/shipments/page.tsx
@@ -53,7 +53,9 @@ const ProposalShipmentsPage = async (props: { params: Promise<{ proposalId: stri
               ))}
             </VStack>
           ) : (
-            <Heading variant="notFound" size="md">No shipments found</Heading>
+            <Heading variant='notFound' size='md'>
+              No shipments found
+            </Heading>
           )}
         </VStack>
         <VStack alignItems='start' flexBasis='400px'>

--- a/src/components/containers/Cassette.test.tsx
+++ b/src/components/containers/Cassette.test.tsx
@@ -11,8 +11,8 @@ const defaultSample: components["schemas"]["SampleOut"] = {
   shipmentId: 1,
   proteinId: 1,
   details: {
-    concentration: 1
-  }
+    concentration: 1,
+  },
 };
 
 describe("Cassette", () => {

--- a/src/components/navigation/SampleCard.tsx
+++ b/src/components/navigation/SampleCard.tsx
@@ -34,9 +34,9 @@ export const SampleCard = ({ sample, params }: SampleCardProps) => {
   return (
     <Box w='100%' key={sample.id}>
       <Stat
-        bg='gray.100'
+        bg='gray.50'
         p='10px'
-        border='1px solid black'
+        border='1px solid #EDF2F7'
         borderBottom='none'
         borderRadius='0'
         m='0'

--- a/src/components/navigation/ShipmentCard.test.tsx
+++ b/src/components/navigation/ShipmentCard.test.tsx
@@ -1,0 +1,30 @@
+import { renderWithProviders } from "@/utils/test-utils";
+import { screen } from "@testing-library/react";
+import { ShipmentCard } from "./ShipmentCard";
+import { components } from "@/types/schema";
+
+const baseShipment: components["schemas"]["ShipmentOut"] = {
+  id: 1,
+  name: "new-shipment",
+  creationDate: "2025-01-01 01:01:01",
+  proposalCode: "cm",
+  proposalNumber: 12345,
+  visitNumber: 1,
+  lastStatusUpdate: "2025-01-01 01:01:01"
+};
+
+describe("Shipment Card", () => {
+  it("should render shipment card", () => {
+    renderWithProviders(<ShipmentCard shipment={baseShipment} />);
+
+    expect(screen.getByText("new-shipment")).toBeInTheDocument();
+  });
+
+  it("should render '?' if no valid date is provided", () => {
+    renderWithProviders(
+      <ShipmentCard shipment={{...baseShipment, creationDate: null}} />
+    );
+
+    expect(screen.getByText("Creation Date: ?")).toBeInTheDocument()
+  });
+});

--- a/src/components/navigation/ShipmentCard.test.tsx
+++ b/src/components/navigation/ShipmentCard.test.tsx
@@ -10,7 +10,7 @@ const baseShipment: components["schemas"]["ShipmentOut"] = {
   proposalCode: "cm",
   proposalNumber: 12345,
   visitNumber: 1,
-  lastStatusUpdate: "2025-01-01 01:01:01"
+  lastStatusUpdate: "2025-01-01 01:01:01",
 };
 
 describe("Shipment Card", () => {
@@ -21,10 +21,8 @@ describe("Shipment Card", () => {
   });
 
   it("should render '?' if no valid date is provided", () => {
-    renderWithProviders(
-      <ShipmentCard shipment={{...baseShipment, creationDate: null}} />
-    );
+    renderWithProviders(<ShipmentCard shipment={{ ...baseShipment, creationDate: null }} />);
 
-    expect(screen.getByText("Creation Date: ?")).toBeInTheDocument()
+    expect(screen.getByText("Creation Date: ?")).toBeInTheDocument();
   });
 });

--- a/src/components/navigation/ShipmentCard.tsx
+++ b/src/components/navigation/ShipmentCard.tsx
@@ -12,8 +12,7 @@ import {
   Link,
 } from "@chakra-ui/react";
 import NextLink from "next/link";
-import { ShipmentParams } from "@/types/generic";
-import { getShipmentStatus, VALID_SHIPMENT_STATUSES } from "@/mappings/colours";
+import { getShipmentStatus } from "@/mappings/colours";
 import { formatDate } from "@/utils/generic";
 
 export interface ShipmentCardProps {
@@ -53,13 +52,23 @@ export const ShipmentCard = ({ shipment }: ShipmentCardProps) => {
             as={NextLink}
             href={`${urlPrefix}${shipment.proposalCode}${shipment.proposalNumber}/sessions/${shipment.visitNumber}/shipments/${shipment.id}`}
           >
-            View Shipment
+            View Sample Collection
           </Button>
         </HStack>
       </Stat>
-      <HStack w='100%' bg='gray.100' fontSize='14px' fontWeight='600' p='5px' justifyContent="space-between">
+      <HStack
+        w='100%'
+        bg='gray.100'
+        fontSize='14px'
+        fontWeight='600'
+        p='5px'
+        justifyContent='space-between'
+      >
         <Text>
-            Session: <Link>{shipment.visitNumber}</Link>
+          Session:{" "}
+          <Link as={NextLink} href={`sessions/${shipment.visitNumber}/shipments`}>
+            {shipment.visitNumber}
+          </Link>
         </Text>
         <Text>
           Creation Date: {shipment.creationDate ? formatDate(shipment.creationDate) : "?"}

--- a/src/components/navigation/ShipmentCard.tsx
+++ b/src/components/navigation/ShipmentCard.tsx
@@ -17,7 +17,7 @@ import { getShipmentStatus, VALID_SHIPMENT_STATUSES } from "@/mappings/colours";
 import { formatDate } from "@/utils/generic";
 
 export interface ShipmentCardProps {
-  /** Sample to display */
+  /** Sample collection to display */
   shipment: components["schemas"]["ShipmentOut"];
 }
 
@@ -62,7 +62,7 @@ export const ShipmentCard = ({ shipment }: ShipmentCardProps) => {
             Session: <Link>{shipment.visitNumber}</Link>
         </Text>
         <Text>
-          Creation Date: {shipment.creationDate ? formatDate(shipment.creationDate) : "Unknown"}
+          Creation Date: {shipment.creationDate ? formatDate(shipment.creationDate) : "?"}
         </Text>
       </HStack>
     </Box>

--- a/src/components/navigation/ShipmentCard.tsx
+++ b/src/components/navigation/ShipmentCard.tsx
@@ -1,0 +1,70 @@
+import { components } from "@/types/schema";
+import {
+  Box,
+  Stat,
+  HStack,
+  VStack,
+  StatLabel,
+  Heading,
+  Tag,
+  Button,
+  Text,
+  Link,
+} from "@chakra-ui/react";
+import NextLink from "next/link";
+import { ShipmentParams } from "@/types/generic";
+import { getShipmentStatus, VALID_SHIPMENT_STATUSES } from "@/mappings/colours";
+import { formatDate } from "@/utils/generic";
+
+export interface ShipmentCardProps {
+  /** Sample to display */
+  shipment: components["schemas"]["ShipmentOut"];
+}
+
+/**
+ * A view that displays sample information and provides links to descendents, ancestors, collected data, and itself.
+ *
+ * This is a server-rendered component.
+ */
+export const ShipmentCard = ({ shipment }: ShipmentCardProps) => {
+  const urlPrefix = `/proposals/`;
+
+  return (
+    <Box w='100%' key={shipment.id} border='1px solid #EDF2F7'>
+      <Stat bg='gray.50' p='10px' m='0'>
+        <HStack flexWrap='wrap'>
+          <VStack alignItems='start' flex='1 0 0' minW='200px'>
+            <StatLabel flexDirection='row' display='flex' gap='1em' flexWrap='wrap'>
+              <Heading
+                size='md'
+                textOverflow='ellipsis'
+                overflow='hidden'
+                whiteSpace='nowrap'
+                maxW='15vw'
+              >
+                {shipment.name}
+              </Heading>
+              <Tag colorScheme={getShipmentStatus(shipment).colour}>
+                {getShipmentStatus(shipment).statusText}
+              </Tag>
+            </StatLabel>
+          </VStack>
+          <Button
+            as={NextLink}
+            href={`${urlPrefix}${shipment.proposalCode}${shipment.proposalNumber}/sessions/${shipment.visitNumber}/shipments/${shipment.id}`}
+          >
+            View Shipment
+          </Button>
+        </HStack>
+      </Stat>
+      <HStack w='100%' bg='gray.100' fontSize='14px' fontWeight='600' p='5px' justifyContent="space-between">
+        <Text>
+            Session: <Link>{shipment.visitNumber}</Link>
+        </Text>
+        <Text>
+          Creation Date: {shipment.creationDate ? formatDate(shipment.creationDate) : "Unknown"}
+        </Text>
+      </HStack>
+    </Box>
+  );
+};

--- a/src/mappings/colours.ts
+++ b/src/mappings/colours.ts
@@ -1,0 +1,30 @@
+import { components } from "@/types/schema";
+
+export const VALID_SHIPMENT_STATUSES: Record<string, string> = {
+  "at facility": "green",
+  processing: "green",
+  opened: "green",
+  "awb created": "yellow",
+  "sent to facility": "yellow",
+  "Created": "yellow",
+  "dispatch-requested": "purple",
+  "pickup booked": "purple",
+  "transfer-requested": "purple",
+  "pickup cancelled": "red",
+  "Draft": "gray"
+};
+
+export const getShipmentStatus = (shipment: components["schemas"]["ShipmentOut"]) => {
+  if (shipment.status === null || shipment.status === undefined) {
+    const creationStatus = shipment.externalId ? "Submitted" : "Draft";
+    return {
+      colour: creationStatus === "Submitted" ? "green" : "gray",
+      statusText: creationStatus,
+    };
+  }
+
+  return {
+    colour: VALID_SHIPMENT_STATUSES[shipment.status] || "gray",
+    statusText: shipment.status,
+  };
+};

--- a/src/mappings/colours.ts
+++ b/src/mappings/colours.ts
@@ -6,12 +6,12 @@ export const VALID_SHIPMENT_STATUSES: Record<string, string> = {
   opened: "green",
   "awb created": "yellow",
   "sent to facility": "yellow",
-  "Created": "yellow",
+  Created: "yellow",
   "dispatch-requested": "purple",
   "pickup booked": "purple",
   "transfer-requested": "purple",
   "pickup cancelled": "red",
-  "Draft": "gray"
+  Draft: "gray",
 };
 
 export const getShipmentStatus = (shipment: components["schemas"]["ShipmentOut"]) => {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -5,6 +5,7 @@ export const defaultData: BaseShipmentItem = {
   id: 1,
   name: "Shipment",
   type: "shipment",
+  visitNumber: 1,
   data: { proposalNumber: "123", proposalCode: "cm", visitNumber: 1 },
   children: [
     {
@@ -51,12 +52,22 @@ export const handlers = [
 
   http.get(
     "http://localhost/api/proposals/:proposalReference/sessions/:visitNumber/shipments",
-    () => HttpResponse.json({ items: [defaultData] }),
+    () => HttpResponse.json({ items: [defaultData], 
+      total: 2, }),
   ),
 
-  http.get(
-    "http://localhost/api/proposals/:proposalReference/shipments",
-    () => HttpResponse.json({ items: [defaultData] }),
+  http.get("http://localhost/api/proposals/:proposalReference/shipments", () =>
+    HttpResponse.json({ items: [defaultData] }),
+  ),
+
+  http.get("http://localhost/api/sessions", () =>
+    HttpResponse.json({
+      items: [
+        { visitNumber: 1, parentProposal: "cm1234", sessionId: 1 },
+        { visitNumber: 2, parentProposal: "cm1234", sessionId: 2 },
+      ],
+      total: 2,
+    }),
   ),
 
   http.get("http://localhost/api/shipments/:shipmentId", () => HttpResponse.json(defaultData)),

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -52,8 +52,7 @@ export const handlers = [
 
   http.get(
     "http://localhost/api/proposals/:proposalReference/sessions/:visitNumber/shipments",
-    () => HttpResponse.json({ items: [defaultData], 
-      total: 2, }),
+    () => HttpResponse.json({ items: [defaultData], total: 2 }),
   ),
 
   http.get("http://localhost/api/proposals/:proposalReference/shipments", () =>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -54,6 +54,11 @@ export const handlers = [
     () => HttpResponse.json({ items: [defaultData] }),
   ),
 
+  http.get(
+    "http://localhost/api/proposals/:proposalReference/shipments",
+    () => HttpResponse.json({ items: [defaultData] }),
+  ),
+
   http.get("http://localhost/api/shipments/:shipmentId", () => HttpResponse.json(defaultData)),
 
   http.post("http://localhost/api/shipments/:shipmentId/push", () =>

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -4,2360 +4,2360 @@
  */
 
 export interface paths {
-    "/shipments/{shipmentId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Shipment
-         * @description Get shipment data
-         */
-        get: operations["get_shipment_shipments__shipmentId__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/shipments/{shipmentId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/unassigned": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Unassigned Items
-         * @description Get unassigned items in shipment
-         */
-        get: operations["get_unassigned_items_shipments__shipmentId__unassigned_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Shipment
+     * @description Get shipment data
+     */
+    get: operations["get_shipment_shipments__shipmentId__get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/unassigned": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/push": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Push Shipment
-         * @description Push shipment to ISPyB. Unassigned containers (such as a container with no parent top level
-         *     container) are ignored. Unassigned samples are pushed to ISPyB.
-         */
-        post: operations["push_shipment_shipments__shipmentId__push_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Unassigned Items
+     * @description Get unassigned items in shipment
+     */
+    get: operations["get_unassigned_items_shipments__shipmentId__unassigned_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/push": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/topLevelContainers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Top Level Containers
-         * @description Get top level containers in shipment
-         */
-        get: operations["get_top_level_containers_shipments__shipmentId__topLevelContainers_get"];
-        put?: never;
-        /**
-         * Create Top Level Container
-         * @description Create new container in shipment. If the top level container type is 'dewar' and the provided code is
-         *     empty or null, a new one is created.
-         */
-        post: operations["create_top_level_container_shipments__shipmentId__topLevelContainers_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Push Shipment
+     * @description Push shipment to ISPyB. Unassigned containers (such as a container with no parent top level
+     *     container) are ignored. Unassigned samples are pushed to ISPyB.
+     */
+    post: operations["push_shipment_shipments__shipmentId__push_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/topLevelContainers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/containers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Container
-         * @description Create new container in shipment
-         */
-        post: operations["create_container_shipments__shipmentId__containers_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Top Level Containers
+     * @description Get top level containers in shipment
+     */
+    get: operations["get_top_level_containers_shipments__shipmentId__topLevelContainers_get"];
+    put?: never;
+    /**
+     * Create Top Level Container
+     * @description Create new container in shipment. If the top level container type is 'dewar' and the provided code is
+     *     empty or null, a new one is created.
+     */
+    post: operations["create_top_level_container_shipments__shipmentId__topLevelContainers_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/containers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/samples": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Samples
-         * @description Get samples in shipment
-         */
-        get: operations["get_samples_shipments__shipmentId__samples_get"];
-        put?: never;
-        /**
-         * Create Sample
-         * @description Create new sample in shipment
-         */
-        post: operations["create_sample_shipments__shipmentId__samples_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Create Container
+     * @description Create new container in shipment
+     */
+    post: operations["create_container_shipments__shipmentId__containers_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/samples": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/request": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Shipment Request
-         * @description Get shipment request
-         */
-        get: operations["get_shipment_request_shipments__shipmentId__request_get"];
-        put?: never;
-        /**
-         * Create Shipment Request
-         * @description Create new shipment request
-         */
-        post: operations["create_shipment_request_shipments__shipmentId__request_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Samples
+     * @description Get samples in shipment
+     */
+    get: operations["get_samples_shipments__shipmentId__samples_get"];
+    put?: never;
+    /**
+     * Create Sample
+     * @description Create new sample in shipment
+     */
+    post: operations["create_sample_shipments__shipmentId__samples_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/request": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/preSession": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Pre Session
-         * @description Create new pre session information
-         */
-        get: operations["get_pre_session_shipments__shipmentId__preSession_get"];
-        /**
-         * Create Pre Session
-         * @description Upsert new pre session information
-         */
-        put: operations["create_pre_session_shipments__shipmentId__preSession_put"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Shipment Request
+     * @description Get shipment request
+     */
+    get: operations["get_shipment_request_shipments__shipmentId__request_get"];
+    put?: never;
+    /**
+     * Create Shipment Request
+     * @description Create new shipment request
+     */
+    post: operations["create_shipment_request_shipments__shipmentId__request_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/preSession": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/tracking-labels": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Shipping Labels
-         * @description Get shipping labels for dewar
-         */
-        get: operations["get_shipping_labels_shipments__shipmentId__tracking_labels_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Pre Session
+     * @description Create new pre session information
+     */
+    get: operations["get_pre_session_shipments__shipmentId__preSession_get"];
+    /**
+     * Create Pre Session
+     * @description Upsert new pre session information
+     */
+    put: operations["create_pre_session_shipments__shipmentId__preSession_put"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/tracking-labels": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/update-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Update Shipment Status
-         * @description Update shipment status
-         */
-        post: operations["update_shipment_status_shipments__shipmentId__update_status_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Shipping Labels
+     * @description Get shipping labels for dewar
+     */
+    get: operations["get_shipping_labels_shipments__shipmentId__tracking_labels_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/update-status": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/assign-data-collection-groups": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Assign Dcg In Sublocation
-         * @description Update data collection group sample ID in ISPyB. Does not return data.
-         */
-        post: operations["assign_dcg_in_sublocation_shipments__shipmentId__assign_data_collection_groups_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Update Shipment Status
+     * @description Update shipment status
+     */
+    post: operations["update_shipment_status_shipments__shipmentId__update_status_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/assign-data-collection-groups": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/shipments/{shipmentId}/pdf-report": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Pdf Report
-         * @description Get PDF report of shipment
-         */
-        get: operations["get_pdf_report_shipments__shipmentId__pdf_report_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Assign Dcg In Sublocation
+     * @description Update data collection group sample ID in ISPyB. Does not return data.
+     */
+    post: operations["assign_dcg_in_sublocation_shipments__shipmentId__assign_data_collection_groups_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/shipments/{shipmentId}/pdf-report": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/proposals/{proposalReference}/sessions/{visitNumber}/shipments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Shipments
-         * @description Get shipments in session
-         */
-        get: operations["get_shipments_proposals__proposalReference__sessions__visitNumber__shipments_get"];
-        put?: never;
-        /**
-         * Create Shipment
-         * @description Create new shipment in session
-         */
-        post: operations["create_shipment_proposals__proposalReference__sessions__visitNumber__shipments_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Pdf Report
+     * @description Get PDF report of shipment
+     */
+    get: operations["get_pdf_report_shipments__shipmentId__pdf_report_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/proposals/{proposalReference}/sessions/{visitNumber}/shipments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/proposals/{proposalReference}/sessions/{visitNumber}/samples": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Samples
-         * @description Get samples in session
-         */
-        get: operations["get_samples_proposals__proposalReference__sessions__visitNumber__samples_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Shipments
+     * @description Get shipments in session
+     */
+    get: operations["get_shipments_proposals__proposalReference__sessions__visitNumber__shipments_get"];
+    put?: never;
+    /**
+     * Create Shipment
+     * @description Create new shipment in session
+     */
+    post: operations["create_shipment_proposals__proposalReference__sessions__visitNumber__shipments_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/proposals/{proposalReference}/sessions/{visitNumber}/samples": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/proposals/{proposalReference}/sessions/{visitNumber}/containers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Containers
-         * @description Get containers in session
-         */
-        get: operations["get_containers_proposals__proposalReference__sessions__visitNumber__containers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Samples
+     * @description Get samples in session
+     */
+    get: operations["get_samples_proposals__proposalReference__sessions__visitNumber__samples_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/proposals/{proposalReference}/sessions/{visitNumber}/containers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/proposals/{proposalReference}/data": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Shipment Data
-         * @description Get lab data for the proposal (lab contacts, proteins...)
-         *
-         *     We can skip auth on this one since it is calling Expeye, and auth is done there
-         */
-        get: operations["get_shipment_data_proposals__proposalReference__data_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Containers
+     * @description Get containers in session
+     */
+    get: operations["get_containers_proposals__proposalReference__sessions__visitNumber__containers_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/proposals/{proposalReference}/data": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/proposals/{proposalReference}/shipments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Proposal Shipments
-         * @description Get shipments in proposal
-         */
-        get: operations["get_proposal_shipments_proposals__proposalReference__shipments_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Shipment Data
+     * @description Get lab data for the proposal (lab contacts, proteins...)
+     *
+     *     We can skip auth on this one since it is calling Expeye, and auth is done there
+     */
+    get: operations["get_shipment_data_proposals__proposalReference__data_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/proposals/{proposalReference}/shipments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/proposals/{proposalReference}/sessions/{visitNumber}/assign-data-collection-groups": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Assign Dcg In Sublocation
-         * @description Update data collection group sample ID in ISPyB. Does not return data.
-         */
-        post: operations["assign_dcg_in_sublocation_proposals__proposalReference__sessions__visitNumber__assign_data_collection_groups_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Proposal Shipments
+     * @description Get shipments in proposal
+     */
+    get: operations["get_proposal_shipments_proposals__proposalReference__shipments_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/proposals/{proposalReference}/sessions/{visitNumber}/assign-data-collection-groups": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/samples/{sampleId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Sample
-         * @description Create new sample in shipment
-         */
-        delete: operations["delete_sample_samples__sampleId__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Edit Sample
-         * @description Edit existing sample
-         */
-        patch: operations["edit_sample_samples__sampleId__patch"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Assign Dcg In Sublocation
+     * @description Update data collection group sample ID in ISPyB. Does not return data.
+     */
+    post: operations["assign_dcg_in_sublocation_proposals__proposalReference__sessions__visitNumber__assign_data_collection_groups_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/samples/{sampleId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/containers/{containerId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Container
-         * @description Get container
-         */
-        get: operations["get_container_containers__containerId__get"];
-        put?: never;
-        post?: never;
-        /**
-         * Delete Container
-         * @description Delete container in shipment
-         */
-        delete: operations["delete_container_containers__containerId__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Edit Container
-         * @description Edit existing container
-         */
-        patch: operations["edit_container_containers__containerId__patch"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Delete Sample
+     * @description Create new sample in shipment
+     */
+    delete: operations["delete_sample_samples__sampleId__delete"];
+    options?: never;
+    head?: never;
+    /**
+     * Edit Sample
+     * @description Edit existing sample
+     */
+    patch: operations["edit_sample_samples__sampleId__patch"];
+    trace?: never;
+  };
+  "/containers/{containerId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/topLevelContainers/{topLevelContainerId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Container
-         * @description Create new container in shipment
-         */
-        delete: operations["delete_container_topLevelContainers__topLevelContainerId__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Edit Container
-         * @description Edit existing container
-         */
-        patch: operations["edit_container_topLevelContainers__topLevelContainerId__patch"];
-        trace?: never;
+    /**
+     * Get Container
+     * @description Get container
+     */
+    get: operations["get_container_containers__containerId__get"];
+    put?: never;
+    post?: never;
+    /**
+     * Delete Container
+     * @description Delete container in shipment
+     */
+    delete: operations["delete_container_containers__containerId__delete"];
+    options?: never;
+    head?: never;
+    /**
+     * Edit Container
+     * @description Edit existing container
+     */
+    patch: operations["edit_container_containers__containerId__patch"];
+    trace?: never;
+  };
+  "/topLevelContainers/{topLevelContainerId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/internal-containers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Internal Containers
-         * @description Get internal top level containers
-         */
-        get: operations["get_internal_containers_internal_containers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Delete Container
+     * @description Create new container in shipment
+     */
+    delete: operations["delete_container_topLevelContainers__topLevelContainerId__delete"];
+    options?: never;
+    head?: never;
+    /**
+     * Edit Container
+     * @description Edit existing container
+     */
+    patch: operations["edit_container_topLevelContainers__topLevelContainerId__patch"];
+    trace?: never;
+  };
+  "/internal-containers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/internal-containers/unassigned": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Unassigned Internal Containers
-         * @description Get orphan internal containers
-         */
-        get: operations["get_unassigned_internal_containers_internal_containers_unassigned_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Internal Containers
+     * @description Get internal top level containers
+     */
+    get: operations["get_internal_containers_internal_containers_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/internal-containers/unassigned": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/internal-containers/containers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Orphan Container
-         * @description Create orphan container
-         */
-        post: operations["create_orphan_container_internal_containers_containers_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Unassigned Internal Containers
+     * @description Get orphan internal containers
+     */
+    get: operations["get_unassigned_internal_containers_internal_containers_unassigned_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/internal-containers/containers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/internal-containers/topLevelContainers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Orphan Top Level Container
-         * @description Create orphan container
-         */
-        post: operations["create_orphan_top_level_container_internal_containers_topLevelContainers_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Create Orphan Container
+     * @description Create orphan container
+     */
+    post: operations["create_orphan_container_internal_containers_containers_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/internal-containers/topLevelContainers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/internal-containers/{topLevelContainerId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Internal Container
-         * @description Get internal top level container and its children
-         */
-        get: operations["get_internal_container_internal_containers__topLevelContainerId__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Create Orphan Top Level Container
+     * @description Create orphan container
+     */
+    post: operations["create_orphan_top_level_container_internal_containers_topLevelContainers_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/internal-containers/{topLevelContainerId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/sessions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Sessions
-         * @description Get sessions a user can view (wrapper for Expeye endpoint)
-         */
-        get: operations["get_sessions_sessions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get Internal Container
+     * @description Get internal top level container and its children
+     */
+    get: operations["get_internal_container_internal_containers__topLevelContainerId__get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/sessions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    /**
+     * Get Sessions
+     * @description Get sessions a user can view (wrapper for Expeye endpoint)
+     */
+    get: operations["get_sessions_sessions_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        /** ContainerIn */
-        ContainerIn: {
-            /** Toplevelcontainerid */
-            topLevelContainerId?: number | null;
-            /** Parentid */
-            parentId?: number | null;
-            /** Capacity */
-            capacity?: number | null;
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /** Location */
-            location?: number | null;
-            /**
-             * Requestedreturn
-             * @default false
-             */
-            requestedReturn: boolean | null;
-            /** Registeredcontainer */
-            registeredContainer?: string | null;
-            /** Subtype */
-            subType?: string | null;
-            /**
-             * Name
-             * @description Base container name. If name is not provided, the container's type followedby the container index is used
-             */
-            name?: string | null;
-            /** Comments */
-            comments?: string | null;
-            /** Type */
-            type: string;
-            /**
-             * Isinternal
-             * @default false
-             */
-            isInternal: boolean;
-        };
-        /** ContainerOut */
-        ContainerOut: {
-            /** Toplevelcontainerid */
-            topLevelContainerId?: number | null;
-            /** Parentid */
-            parentId?: number | null;
-            /** Capacity */
-            capacity?: number | null;
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /** Location */
-            location?: number | null;
-            /**
-             * Requestedreturn
-             * @default false
-             */
-            requestedReturn: boolean | null;
-            /** Registeredcontainer */
-            registeredContainer?: string | null;
-            /** Subtype */
-            subType?: string | null;
-            /**
-             * Name
-             * @description Base container name. If name is not provided, the container's type followedby the container index is used
-             */
-            name?: string | null;
-            /** Comments */
-            comments?: string | null;
-            /** Shipmentid */
-            shipmentId: number;
-            /** Id */
-            id: number;
-            /** Type */
-            type: string;
-            /** Isinternal */
-            isInternal: boolean;
-            /**
-             * Internalstoragecontainer
-             * @description Internal storage container this container is currently in.Only set if this is stored in the facility
-             */
-            internalStorageContainer?: number | null;
-        };
-        /** GenericItem */
-        GenericItem: {
-            /** Id */
-            id: number;
-            /** Name */
-            name: string;
-            data: components["schemas"]["GenericItemData"];
-            /** Children */
-            children?: components["schemas"]["GenericItem"][] | null;
-        };
-        /** GenericItemData */
-        GenericItemData: {
-            /** Type */
-            type: string;
-        } & {
-            [key: string]: unknown;
-        };
-        /** HTTPValidationError */
-        HTTPValidationError: {
-            /** Detail */
-            detail?: components["schemas"]["ValidationError"][];
-        };
-        /** OptionalContainer */
-        OptionalContainer: {
-            /** Toplevelcontainerid */
-            topLevelContainerId?: number | null;
-            /** Parentid */
-            parentId?: number | null;
-            /** Capacity */
-            capacity?: number | null;
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /** Location */
-            location?: number | null;
-            /**
-             * Requestedreturn
-             * @default false
-             */
-            requestedReturn: boolean | null;
-            /** Registeredcontainer */
-            registeredContainer?: string | null;
-            /** Subtype */
-            subType?: string | null;
-            /**
-             * Name
-             * @description Base container name. If name is not provided, the container's type followedby the container index is used
-             */
-            name?: string | null;
-            /** Comments */
-            comments?: string | null;
-            /** Type */
-            type?: string | null;
-            /** Shipmentid */
-            shipmentId?: number | null;
-            /** Isinternal */
-            isInternal?: boolean | null;
-        };
-        /** OptionalSample */
-        OptionalSample: {
-            /** Containerid */
-            containerId?: number | null;
-            /** Location */
-            location?: number | null;
-            /** Sublocation */
-            subLocation?: number | null;
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /** Comments */
-            comments?: string | null;
-            /**
-             * Name
-             * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
-             */
-            name?: string | null;
-            /** Proteinid */
-            proteinId?: number | null;
-            /** Type */
-            type?: string | null;
-            /** Shipmentid */
-            shipmentId?: number | null;
-        };
-        /** OptionalTopLevelContainer */
-        OptionalTopLevelContainer: {
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /** Comments */
-            comments?: string | null;
-            /**
-             * Name
-             * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
-             */
-            name?: string | null;
-            /** Type */
-            type?: string | null;
-            /** Code */
-            code?: string | null;
-            /** Barcode */
-            barCode?: string | null;
-        };
-        /** Paged[ContainerOut] */
-        Paged_ContainerOut_: {
-            /** Items */
-            items: components["schemas"]["ContainerOut"][];
-            /** Total */
-            total: number;
-            /** Page */
-            page: number;
-            /** Limit */
-            limit: number;
-        };
-        /** Paged[GenericItem] */
-        Paged_GenericItem_: {
-            /** Items */
-            items: components["schemas"]["GenericItem"][];
-            /** Total */
-            total: number;
-            /** Page */
-            page: number;
-            /** Limit */
-            limit: number;
-        };
-        /** Paged[SampleOut] */
-        Paged_SampleOut_: {
-            /** Items */
-            items: components["schemas"]["SampleOut"][];
-            /** Total */
-            total: number;
-            /** Page */
-            page: number;
-            /** Limit */
-            limit: number;
-        };
-        /** Paged[SessionOut] */
-        Paged_SessionOut_: {
-            /** Items */
-            items: components["schemas"]["SessionOut"][];
-            /** Total */
-            total: number;
-            /** Page */
-            page: number;
-            /** Limit */
-            limit: number;
-        };
-        /** Paged[ShipmentOut] */
-        Paged_ShipmentOut_: {
-            /** Items */
-            items: components["schemas"]["ShipmentOut"][];
-            /** Total */
-            total: number;
-            /** Page */
-            page: number;
-            /** Limit */
-            limit: number;
-        };
-        /** Paged[TopLevelContainerOut] */
-        Paged_TopLevelContainerOut_: {
-            /** Items */
-            items: components["schemas"]["TopLevelContainerOut"][];
-            /** Total */
-            total: number;
-            /** Page */
-            page: number;
-            /** Limit */
-            limit: number;
-        };
-        /** PreSessionIn */
-        PreSessionIn: {
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-        };
-        /** PreSessionOut */
-        PreSessionOut: {
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Islocked
-             * @default false
-             */
-            isLocked: boolean;
-        };
-        /** SampleIn */
-        SampleIn: {
-            /** Containerid */
-            containerId?: number | null;
-            /** Location */
-            location?: number | null;
-            /** Sublocation */
-            subLocation?: number | null;
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /** Comments */
-            comments?: string | null;
-            /**
-             * Name
-             * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
-             */
-            name?: string | null;
-            /** Proteinid */
-            proteinId: number;
-            /** Type */
-            type?: string | null;
-            /**
-             * Copies
-             * @default 1
-             */
-            copies: number;
-            /** Parents */
-            parents?: number[] | null;
-        };
-        /** SampleOut */
-        SampleOut: {
-            /** Containerid */
-            containerId?: number | null;
-            /** Location */
-            location?: number | null;
-            /** Sublocation */
-            subLocation?: number | null;
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /** Comments */
-            comments?: string | null;
-            /**
-             * Name
-             * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
-             */
-            name?: string | null;
-            /** Id */
-            id: number;
-            /** Shipmentid */
-            shipmentId: number;
-            /** Proteinid */
-            proteinId: number;
-            /** Containername */
-            containerName?: string | null;
-            /** Type */
-            type: string;
-            /** Datacollectiongroupid */
-            dataCollectionGroupId?: number | null;
-            /** Parentshipmentname */
-            parentShipmentName?: string | null;
-            /** Originsamples */
-            originSamples?: components["schemas"]["SampleOut"][] | null;
-            /** Derivedsamples */
-            derivedSamples?: components["schemas"]["SampleOut"][] | null;
-            /** Externalid */
-            externalId?: number | null;
-        };
-        /** SessionOut */
-        SessionOut: {
-            /** Beamlinesetupid */
-            beamLineSetupId?: number | null;
-            /** Beamcalendarid */
-            beamCalendarId?: number | null;
-            /** Startdate */
-            startDate?: string | null;
-            /** Enddate */
-            endDate?: string | null;
-            /** Beamlinename */
-            beamLineName?: string | null;
-            /** Scheduled */
-            scheduled?: number | null;
-            /** Nbshifts */
-            nbShifts?: number | null;
-            /** Comments */
-            comments?: string | null;
-            /** Visitnumber */
-            visitNumber?: number | null;
-            /**
-             * Usedflag
-             * @description Indicates if session has Datacollections or XFE or EnergyScans attached
-             */
-            usedFlag?: number | null;
-            /**
-             * Lastupdate
-             * @description Last update timestamp: by default the end of the session, the last collect
-             */
-            lastUpdate?: string | null;
-            /** Parentproposal */
-            parentProposal?: string | null;
-            /**
-             * Proposalid
-             * @description Proposal ID
-             */
-            proposalId: number;
-            /**
-             * Sessionid
-             * @description Session ID
-             */
-            sessionId: number;
-            /** Beamlineoperator */
-            beamLineOperator?: string[] | null;
-            /**
-             * Bltimestamp
-             * Format: date-time
-             */
-            bltimeStamp: string;
-            /** Purgedprocesseddata */
-            purgedProcessedData: boolean;
-            /**
-             * Archived
-             * @description The data for the session is archived and no longer available on disk
-             */
-            archived: number;
-            /** Collectiongroups */
-            collectionGroups?: number | null;
-        };
-        /** ShipmentChildren */
-        ShipmentChildren: {
-            /** Id */
-            id: number;
-            /** Name */
-            name: string;
-            /** Children */
-            children: components["schemas"]["GenericItem"][];
-            /** Data */
-            data: {
-                [key: string]: unknown;
-            };
-        };
-        /** ShipmentIn */
-        ShipmentIn: {
-            /** Name */
-            name: string;
-            /** Comments */
-            comments?: string | null;
-        };
-        /** ShipmentOut */
-        ShipmentOut: {
-            /** Id */
-            id: number;
-            /** Proposalcode */
-            proposalCode: string;
-            /** Proposalnumber */
-            proposalNumber: number;
-            /** Visitnumber */
-            visitNumber: number;
-            /** Name */
-            name: string;
-            /** Comments */
-            comments?: string | null;
-            /** Creationdate */
-            creationDate: string | null;
-            /** Status */
-            status?: string | null;
-            /** Shipmentrequest */
-            shipmentRequest?: number | null;
-            /**
-             * Laststatusupdate
-             * Format: date-time
-             */
-            lastStatusUpdate: string;
-            /** Externalid */
-            externalId?: number | null;
-        };
-        /** StatusUpdate */
-        StatusUpdate: {
-            /** Origin Url */
-            origin_url: string;
-            /** Journey Type */
-            journey_type: string;
-            /** Status */
-            status: string;
-            /** Tracking Number */
-            tracking_number: string;
-            /** Pickup Confirmation Code */
-            pickup_confirmation_code?: string | null;
-            /** Pickup Confirmation Timestamp */
-            pickup_confirmation_timestamp: string | null;
-        };
-        /** SublocationAssignment */
-        SublocationAssignment: {
-            /** Sublocation */
-            subLocation: number;
-            /** Datacollectiongroupid */
-            dataCollectionGroupId: number;
-        };
-        /** TopLevelContainerHistory */
-        TopLevelContainerHistory: {
-            /** Storagelocation */
-            storageLocation?: string | null;
-            /** Dewarid */
-            dewarId: number;
-            /** Dewarstatus */
-            dewarStatus: string;
-            /** Arrivaldate */
-            arrivalDate?: string | null;
-        };
-        /** TopLevelContainerIn */
-        TopLevelContainerIn: {
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /** Comments */
-            comments?: string | null;
-            /**
-             * Name
-             * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
-             */
-            name?: string | null;
-            /** Type */
-            type: string;
-            /** Code */
-            code?: string | null;
-            /**
-             * Isinternal
-             * @default false
-             */
-            isInternal: boolean;
-        };
-        /** TopLevelContainerOut */
-        TopLevelContainerOut: {
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            } | null;
-            /** Comments */
-            comments?: string | null;
-            /**
-             * Name
-             * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
-             */
-            name?: string | null;
-            /** Id */
-            id: number;
-            /** Type */
-            type: string;
-            /** Externalid */
-            externalId?: number | null;
-            /** Barcode */
-            barCode?: string | null;
-            /** History */
-            history?: components["schemas"]["TopLevelContainerHistory"][] | null;
-        };
-        /** UnassignedItems */
-        UnassignedItems: {
-            /** Samples */
-            samples: components["schemas"]["GenericItem"][];
-            /** Gridboxes */
-            gridBoxes: components["schemas"]["GenericItem"][];
-            /** Containers */
-            containers: components["schemas"]["GenericItem"][];
-        };
-        /** ValidationError */
-        ValidationError: {
-            /** Location */
-            loc: (string | number)[];
-            /** Message */
-            msg: string;
-            /** Error Type */
-            type: string;
-        };
+  schemas: {
+    /** ContainerIn */
+    ContainerIn: {
+      /** Toplevelcontainerid */
+      topLevelContainerId?: number | null;
+      /** Parentid */
+      parentId?: number | null;
+      /** Capacity */
+      capacity?: number | null;
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /** Location */
+      location?: number | null;
+      /**
+       * Requestedreturn
+       * @default false
+       */
+      requestedReturn: boolean | null;
+      /** Registeredcontainer */
+      registeredContainer?: string | null;
+      /** Subtype */
+      subType?: string | null;
+      /**
+       * Name
+       * @description Base container name. If name is not provided, the container's type followedby the container index is used
+       */
+      name?: string | null;
+      /** Comments */
+      comments?: string | null;
+      /** Type */
+      type: string;
+      /**
+       * Isinternal
+       * @default false
+       */
+      isInternal: boolean;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    /** ContainerOut */
+    ContainerOut: {
+      /** Toplevelcontainerid */
+      topLevelContainerId?: number | null;
+      /** Parentid */
+      parentId?: number | null;
+      /** Capacity */
+      capacity?: number | null;
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /** Location */
+      location?: number | null;
+      /**
+       * Requestedreturn
+       * @default false
+       */
+      requestedReturn: boolean | null;
+      /** Registeredcontainer */
+      registeredContainer?: string | null;
+      /** Subtype */
+      subType?: string | null;
+      /**
+       * Name
+       * @description Base container name. If name is not provided, the container's type followedby the container index is used
+       */
+      name?: string | null;
+      /** Comments */
+      comments?: string | null;
+      /** Shipmentid */
+      shipmentId: number;
+      /** Id */
+      id: number;
+      /** Type */
+      type: string;
+      /** Isinternal */
+      isInternal: boolean;
+      /**
+       * Internalstoragecontainer
+       * @description Internal storage container this container is currently in.Only set if this is stored in the facility
+       */
+      internalStorageContainer?: number | null;
+    };
+    /** GenericItem */
+    GenericItem: {
+      /** Id */
+      id: number;
+      /** Name */
+      name: string;
+      data: components["schemas"]["GenericItemData"];
+      /** Children */
+      children?: components["schemas"]["GenericItem"][] | null;
+    };
+    /** GenericItemData */
+    GenericItemData: {
+      /** Type */
+      type: string;
+    } & {
+      [key: string]: unknown;
+    };
+    /** HTTPValidationError */
+    HTTPValidationError: {
+      /** Detail */
+      detail?: components["schemas"]["ValidationError"][];
+    };
+    /** OptionalContainer */
+    OptionalContainer: {
+      /** Toplevelcontainerid */
+      topLevelContainerId?: number | null;
+      /** Parentid */
+      parentId?: number | null;
+      /** Capacity */
+      capacity?: number | null;
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /** Location */
+      location?: number | null;
+      /**
+       * Requestedreturn
+       * @default false
+       */
+      requestedReturn: boolean | null;
+      /** Registeredcontainer */
+      registeredContainer?: string | null;
+      /** Subtype */
+      subType?: string | null;
+      /**
+       * Name
+       * @description Base container name. If name is not provided, the container's type followedby the container index is used
+       */
+      name?: string | null;
+      /** Comments */
+      comments?: string | null;
+      /** Type */
+      type?: string | null;
+      /** Shipmentid */
+      shipmentId?: number | null;
+      /** Isinternal */
+      isInternal?: boolean | null;
+    };
+    /** OptionalSample */
+    OptionalSample: {
+      /** Containerid */
+      containerId?: number | null;
+      /** Location */
+      location?: number | null;
+      /** Sublocation */
+      subLocation?: number | null;
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /** Comments */
+      comments?: string | null;
+      /**
+       * Name
+       * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
+       */
+      name?: string | null;
+      /** Proteinid */
+      proteinId?: number | null;
+      /** Type */
+      type?: string | null;
+      /** Shipmentid */
+      shipmentId?: number | null;
+    };
+    /** OptionalTopLevelContainer */
+    OptionalTopLevelContainer: {
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /** Comments */
+      comments?: string | null;
+      /**
+       * Name
+       * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
+       */
+      name?: string | null;
+      /** Type */
+      type?: string | null;
+      /** Code */
+      code?: string | null;
+      /** Barcode */
+      barCode?: string | null;
+    };
+    /** Paged[ContainerOut] */
+    Paged_ContainerOut_: {
+      /** Items */
+      items: components["schemas"]["ContainerOut"][];
+      /** Total */
+      total: number;
+      /** Page */
+      page: number;
+      /** Limit */
+      limit: number;
+    };
+    /** Paged[GenericItem] */
+    Paged_GenericItem_: {
+      /** Items */
+      items: components["schemas"]["GenericItem"][];
+      /** Total */
+      total: number;
+      /** Page */
+      page: number;
+      /** Limit */
+      limit: number;
+    };
+    /** Paged[SampleOut] */
+    Paged_SampleOut_: {
+      /** Items */
+      items: components["schemas"]["SampleOut"][];
+      /** Total */
+      total: number;
+      /** Page */
+      page: number;
+      /** Limit */
+      limit: number;
+    };
+    /** Paged[SessionOut] */
+    Paged_SessionOut_: {
+      /** Items */
+      items: components["schemas"]["SessionOut"][];
+      /** Total */
+      total: number;
+      /** Page */
+      page: number;
+      /** Limit */
+      limit: number;
+    };
+    /** Paged[ShipmentOut] */
+    Paged_ShipmentOut_: {
+      /** Items */
+      items: components["schemas"]["ShipmentOut"][];
+      /** Total */
+      total: number;
+      /** Page */
+      page: number;
+      /** Limit */
+      limit: number;
+    };
+    /** Paged[TopLevelContainerOut] */
+    Paged_TopLevelContainerOut_: {
+      /** Items */
+      items: components["schemas"]["TopLevelContainerOut"][];
+      /** Total */
+      total: number;
+      /** Page */
+      page: number;
+      /** Limit */
+      limit: number;
+    };
+    /** PreSessionIn */
+    PreSessionIn: {
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+    };
+    /** PreSessionOut */
+    PreSessionOut: {
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /**
+       * Islocked
+       * @default false
+       */
+      isLocked: boolean;
+    };
+    /** SampleIn */
+    SampleIn: {
+      /** Containerid */
+      containerId?: number | null;
+      /** Location */
+      location?: number | null;
+      /** Sublocation */
+      subLocation?: number | null;
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /** Comments */
+      comments?: string | null;
+      /**
+       * Name
+       * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
+       */
+      name?: string | null;
+      /** Proteinid */
+      proteinId: number;
+      /** Type */
+      type?: string | null;
+      /**
+       * Copies
+       * @default 1
+       */
+      copies: number;
+      /** Parents */
+      parents?: number[] | null;
+    };
+    /** SampleOut */
+    SampleOut: {
+      /** Containerid */
+      containerId?: number | null;
+      /** Location */
+      location?: number | null;
+      /** Sublocation */
+      subLocation?: number | null;
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /** Comments */
+      comments?: string | null;
+      /**
+       * Name
+       * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
+       */
+      name?: string | null;
+      /** Id */
+      id: number;
+      /** Shipmentid */
+      shipmentId: number;
+      /** Proteinid */
+      proteinId: number;
+      /** Containername */
+      containerName?: string | null;
+      /** Type */
+      type: string;
+      /** Datacollectiongroupid */
+      dataCollectionGroupId?: number | null;
+      /** Parentshipmentname */
+      parentShipmentName?: string | null;
+      /** Originsamples */
+      originSamples?: components["schemas"]["SampleOut"][] | null;
+      /** Derivedsamples */
+      derivedSamples?: components["schemas"]["SampleOut"][] | null;
+      /** Externalid */
+      externalId?: number | null;
+    };
+    /** SessionOut */
+    SessionOut: {
+      /** Beamlinesetupid */
+      beamLineSetupId?: number | null;
+      /** Beamcalendarid */
+      beamCalendarId?: number | null;
+      /** Startdate */
+      startDate?: string | null;
+      /** Enddate */
+      endDate?: string | null;
+      /** Beamlinename */
+      beamLineName?: string | null;
+      /** Scheduled */
+      scheduled?: number | null;
+      /** Nbshifts */
+      nbShifts?: number | null;
+      /** Comments */
+      comments?: string | null;
+      /** Visitnumber */
+      visitNumber?: number | null;
+      /**
+       * Usedflag
+       * @description Indicates if session has Datacollections or XFE or EnergyScans attached
+       */
+      usedFlag?: number | null;
+      /**
+       * Lastupdate
+       * @description Last update timestamp: by default the end of the session, the last collect
+       */
+      lastUpdate?: string | null;
+      /** Parentproposal */
+      parentProposal?: string | null;
+      /**
+       * Proposalid
+       * @description Proposal ID
+       */
+      proposalId: number;
+      /**
+       * Sessionid
+       * @description Session ID
+       */
+      sessionId: number;
+      /** Beamlineoperator */
+      beamLineOperator?: string[] | null;
+      /**
+       * Bltimestamp
+       * Format: date-time
+       */
+      bltimeStamp: string;
+      /** Purgedprocesseddata */
+      purgedProcessedData: boolean;
+      /**
+       * Archived
+       * @description The data for the session is archived and no longer available on disk
+       */
+      archived: number;
+      /** Collectiongroups */
+      collectionGroups?: number | null;
+    };
+    /** ShipmentChildren */
+    ShipmentChildren: {
+      /** Id */
+      id: number;
+      /** Name */
+      name: string;
+      /** Children */
+      children: components["schemas"]["GenericItem"][];
+      /** Data */
+      data: {
+        [key: string]: unknown;
+      };
+    };
+    /** ShipmentIn */
+    ShipmentIn: {
+      /** Name */
+      name: string;
+      /** Comments */
+      comments?: string | null;
+    };
+    /** ShipmentOut */
+    ShipmentOut: {
+      /** Id */
+      id: number;
+      /** Proposalcode */
+      proposalCode: string;
+      /** Proposalnumber */
+      proposalNumber: number;
+      /** Visitnumber */
+      visitNumber: number;
+      /** Name */
+      name: string;
+      /** Comments */
+      comments?: string | null;
+      /** Creationdate */
+      creationDate: string | null;
+      /** Status */
+      status?: string | null;
+      /** Shipmentrequest */
+      shipmentRequest?: number | null;
+      /**
+       * Laststatusupdate
+       * Format: date-time
+       */
+      lastStatusUpdate: string;
+      /** Externalid */
+      externalId?: number | null;
+    };
+    /** StatusUpdate */
+    StatusUpdate: {
+      /** Origin Url */
+      origin_url: string;
+      /** Journey Type */
+      journey_type: string;
+      /** Status */
+      status: string;
+      /** Tracking Number */
+      tracking_number: string;
+      /** Pickup Confirmation Code */
+      pickup_confirmation_code?: string | null;
+      /** Pickup Confirmation Timestamp */
+      pickup_confirmation_timestamp: string | null;
+    };
+    /** SublocationAssignment */
+    SublocationAssignment: {
+      /** Sublocation */
+      subLocation: number;
+      /** Datacollectiongroupid */
+      dataCollectionGroupId: number;
+    };
+    /** TopLevelContainerHistory */
+    TopLevelContainerHistory: {
+      /** Storagelocation */
+      storageLocation?: string | null;
+      /** Dewarid */
+      dewarId: number;
+      /** Dewarstatus */
+      dewarStatus: string;
+      /** Arrivaldate */
+      arrivalDate?: string | null;
+    };
+    /** TopLevelContainerIn */
+    TopLevelContainerIn: {
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /** Comments */
+      comments?: string | null;
+      /**
+       * Name
+       * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
+       */
+      name?: string | null;
+      /** Type */
+      type: string;
+      /** Code */
+      code?: string | null;
+      /**
+       * Isinternal
+       * @default false
+       */
+      isInternal: boolean;
+    };
+    /** TopLevelContainerOut */
+    TopLevelContainerOut: {
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      } | null;
+      /** Comments */
+      comments?: string | null;
+      /**
+       * Name
+       * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
+       */
+      name?: string | null;
+      /** Id */
+      id: number;
+      /** Type */
+      type: string;
+      /** Externalid */
+      externalId?: number | null;
+      /** Barcode */
+      barCode?: string | null;
+      /** History */
+      history?: components["schemas"]["TopLevelContainerHistory"][] | null;
+    };
+    /** UnassignedItems */
+    UnassignedItems: {
+      /** Samples */
+      samples: components["schemas"]["GenericItem"][];
+      /** Gridboxes */
+      gridBoxes: components["schemas"]["GenericItem"][];
+      /** Containers */
+      containers: components["schemas"]["GenericItem"][];
+    };
+    /** ValidationError */
+    ValidationError: {
+      /** Location */
+      loc: (string | number)[];
+      /** Message */
+      msg: string;
+      /** Error Type */
+      type: string;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    get_shipment_shipments__shipmentId__get: {
-        parameters: {
-            query?: {
-                /** @description Whether to get children as part of the request */
-                getChildren?: boolean;
-            };
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ShipmentChildren"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  get_shipment_shipments__shipmentId__get: {
+    parameters: {
+      query?: {
+        /** @description Whether to get children as part of the request */
+        getChildren?: boolean;
+      };
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    get_unassigned_items_shipments__shipmentId__unassigned_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UnassignedItems"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["ShipmentChildren"];
         };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    push_shipment_shipments__shipmentId__push_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  get_unassigned_items_shipments__shipmentId__unassigned_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    get_top_level_containers_shipments__shipmentId__topLevelContainers_get: {
-        parameters: {
-            query?: {
-                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-                page?: number;
-                /** @description Number of results to show */
-                limit?: number;
-            };
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Paged_TopLevelContainerOut_"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["UnassignedItems"];
         };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    create_top_level_container_shipments__shipmentId__topLevelContainers_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TopLevelContainerIn"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TopLevelContainerOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  push_shipment_shipments__shipmentId__push_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    create_container_shipments__shipmentId__containers_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ContainerIn"];
-            };
+        content: {
+          "application/json": unknown;
         };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContainerOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    get_samples_shipments__shipmentId__samples_get: {
-        parameters: {
-            query?: {
-                ignoreExternal?: boolean;
-                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-                page?: number;
-                /** @description Number of results to show */
-                limit?: number;
-            };
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Paged_SampleOut_"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  get_top_level_containers_shipments__shipmentId__topLevelContainers_get: {
+    parameters: {
+      query?: {
+        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+        page?: number;
+        /** @description Number of results to show */
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    create_sample_shipments__shipmentId__samples_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SampleIn"];
-            };
+        content: {
+          "application/json": components["schemas"]["Paged_TopLevelContainerOut_"];
         };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Paged_SampleOut_"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    get_shipment_request_shipments__shipmentId__request_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            307: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  create_top_level_container_shipments__shipmentId__topLevelContainers_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    create_shipment_request_shipments__shipmentId__request_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ShipmentOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["TopLevelContainerIn"];
+      };
     };
-    get_pre_session_shipments__shipmentId__preSession_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PreSessionOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["TopLevelContainerOut"];
         };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    create_pre_session_shipments__shipmentId__preSession_put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PreSessionIn"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PreSessionOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  create_container_shipments__shipmentId__containers_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    get_shipping_labels_shipments__shipmentId__tracking_labels_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                    "application/pdf": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ContainerIn"];
+      };
     };
-    update_shipment_status_shipments__shipmentId__update_status_post: {
-        parameters: {
-            query: {
-                token: string;
-            };
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["StatusUpdate"];
-            };
+        content: {
+          "application/json": components["schemas"]["ContainerOut"];
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ShipmentOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    assign_dcg_in_sublocation_shipments__shipmentId__assign_data_collection_groups_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SublocationAssignment"][];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  get_samples_shipments__shipmentId__samples_get: {
+    parameters: {
+      query?: {
+        ignoreExternal?: boolean;
+        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+        page?: number;
+        /** @description Number of results to show */
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    get_pdf_report_shipments__shipmentId__pdf_report_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                shipmentId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Paged_SampleOut_"];
         };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    get_shipments_proposals__proposalReference__sessions__visitNumber__shipments_get: {
-        parameters: {
-            query?: {
-                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-                page?: number;
-                /** @description Number of results to show */
-                limit?: number;
-            };
-            header?: never;
-            path: {
-                proposalReference: string;
-                visitNumber: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Paged_ShipmentOut_"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  create_sample_shipments__shipmentId__samples_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    create_shipment_proposals__proposalReference__sessions__visitNumber__shipments_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                proposalReference: string;
-                visitNumber: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ShipmentIn"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ShipmentOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SampleIn"];
+      };
     };
-    get_samples_proposals__proposalReference__sessions__visitNumber__samples_get: {
-        parameters: {
-            query?: {
-                ignoreExternal?: boolean;
-                internalOnly?: boolean;
-                ignoreInternal?: boolean;
-                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-                page?: number;
-                /** @description Number of results to show */
-                limit?: number;
-            };
-            header?: never;
-            path: {
-                proposalReference: string;
-                visitNumber: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Paged_SampleOut_"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Paged_SampleOut_"];
         };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    get_containers_proposals__proposalReference__sessions__visitNumber__containers_get: {
-        parameters: {
-            query?: {
-                /** @description Only display containers assigned to internal containers */
-                isInternal?: boolean;
-                /** @description Container type to filter by */
-                type?: string;
-                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-                page?: number;
-                /** @description Number of results to show */
-                limit?: number;
-            };
-            header?: never;
-            path: {
-                proposalReference: string;
-                visitNumber: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Paged_ContainerOut_"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  get_shipment_request_shipments__shipmentId__request_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    get_shipment_data_proposals__proposalReference__data_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                proposalReference: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      307: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    get_proposal_shipments_proposals__proposalReference__shipments_get: {
-        parameters: {
-            query?: {
-                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-                page?: number;
-                /** @description Number of results to show */
-                limit?: number;
-            };
-            header?: never;
-            path: {
-                proposalReference: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  create_shipment_request_shipments__shipmentId__request_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    assign_dcg_in_sublocation_proposals__proposalReference__sessions__visitNumber__assign_data_collection_groups_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                proposalReference: string;
-                visitNumber: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SublocationAssignment"][];
-            };
+        content: {
+          "application/json": components["schemas"]["ShipmentOut"];
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    delete_sample_samples__sampleId__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                sampleId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  get_pre_session_shipments__shipmentId__preSession_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    edit_sample_samples__sampleId__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                sampleId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["OptionalSample"];
-            };
+        content: {
+          "application/json": components["schemas"]["PreSessionOut"];
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SampleOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    get_container_containers__containerId__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                containerId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContainerOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  create_pre_session_shipments__shipmentId__preSession_put: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    delete_container_containers__containerId__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                containerId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PreSessionIn"];
+      };
     };
-    edit_container_containers__containerId__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                containerId: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["OptionalContainer"];
-            };
+        content: {
+          "application/json": components["schemas"]["PreSessionOut"];
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContainerOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    delete_container_topLevelContainers__topLevelContainerId__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                topLevelContainerId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  get_shipping_labels_shipments__shipmentId__tracking_labels_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    edit_container_topLevelContainers__topLevelContainerId__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                topLevelContainerId: number;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["OptionalTopLevelContainer"];
-            };
+        content: {
+          "application/json": unknown;
+          "application/pdf": unknown;
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TopLevelContainerOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    get_internal_containers_internal_containers_get: {
-        parameters: {
-            query?: {
-                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-                page?: number;
-                /** @description Number of results to show */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Paged_TopLevelContainerOut_"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  update_shipment_status_shipments__shipmentId__update_status_post: {
+    parameters: {
+      query: {
+        token: string;
+      };
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    get_unassigned_internal_containers_internal_containers_unassigned_get: {
-        parameters: {
-            query?: {
-                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-                page?: number;
-                /** @description Number of results to show */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Paged_GenericItem_"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["StatusUpdate"];
+      };
     };
-    create_orphan_container_internal_containers_containers_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ContainerIn"];
-            };
+        content: {
+          "application/json": components["schemas"]["ShipmentOut"];
         };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContainerOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
-    create_orphan_top_level_container_internal_containers_topLevelContainers_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TopLevelContainerIn"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TopLevelContainerOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  assign_dcg_in_sublocation_shipments__shipmentId__assign_data_collection_groups_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
     };
-    get_internal_container_internal_containers__topLevelContainerId__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                topLevelContainerId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ShipmentChildren"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SublocationAssignment"][];
+      };
     };
-    get_sessions_sessions_get: {
-        parameters: {
-            query?: {
-                minEndDate?: string | null;
-                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-                page?: number;
-                /** @description Number of results to show */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Paged_SessionOut_"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
+  };
+  get_pdf_report_shipments__shipmentId__pdf_report_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        shipmentId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_shipments_proposals__proposalReference__sessions__visitNumber__shipments_get: {
+    parameters: {
+      query?: {
+        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+        page?: number;
+        /** @description Number of results to show */
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        proposalReference: string;
+        visitNumber: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Paged_ShipmentOut_"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  create_shipment_proposals__proposalReference__sessions__visitNumber__shipments_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        proposalReference: string;
+        visitNumber: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ShipmentIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ShipmentOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_samples_proposals__proposalReference__sessions__visitNumber__samples_get: {
+    parameters: {
+      query?: {
+        ignoreExternal?: boolean;
+        internalOnly?: boolean;
+        ignoreInternal?: boolean;
+        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+        page?: number;
+        /** @description Number of results to show */
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        proposalReference: string;
+        visitNumber: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Paged_SampleOut_"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_containers_proposals__proposalReference__sessions__visitNumber__containers_get: {
+    parameters: {
+      query?: {
+        /** @description Only display containers assigned to internal containers */
+        isInternal?: boolean;
+        /** @description Container type to filter by */
+        type?: string;
+        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+        page?: number;
+        /** @description Number of results to show */
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        proposalReference: string;
+        visitNumber: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Paged_ContainerOut_"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_shipment_data_proposals__proposalReference__data_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        proposalReference: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_proposal_shipments_proposals__proposalReference__shipments_get: {
+    parameters: {
+      query?: {
+        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+        page?: number;
+        /** @description Number of results to show */
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        proposalReference: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  assign_dcg_in_sublocation_proposals__proposalReference__sessions__visitNumber__assign_data_collection_groups_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        proposalReference: string;
+        visitNumber: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SublocationAssignment"][];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  delete_sample_samples__sampleId__delete: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        sampleId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  edit_sample_samples__sampleId__patch: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        sampleId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["OptionalSample"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SampleOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_container_containers__containerId__get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        containerId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ContainerOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  delete_container_containers__containerId__delete: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        containerId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  edit_container_containers__containerId__patch: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        containerId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["OptionalContainer"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ContainerOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  delete_container_topLevelContainers__topLevelContainerId__delete: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        topLevelContainerId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  edit_container_topLevelContainers__topLevelContainerId__patch: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        topLevelContainerId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["OptionalTopLevelContainer"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["TopLevelContainerOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_internal_containers_internal_containers_get: {
+    parameters: {
+      query?: {
+        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+        page?: number;
+        /** @description Number of results to show */
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Paged_TopLevelContainerOut_"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_unassigned_internal_containers_internal_containers_unassigned_get: {
+    parameters: {
+      query?: {
+        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+        page?: number;
+        /** @description Number of results to show */
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Paged_GenericItem_"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  create_orphan_container_internal_containers_containers_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ContainerIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ContainerOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  create_orphan_top_level_container_internal_containers_topLevelContainers_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["TopLevelContainerIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["TopLevelContainerOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_internal_container_internal_containers__topLevelContainerId__get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        topLevelContainerId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ShipmentChildren"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_sessions_sessions_get: {
+    parameters: {
+      query?: {
+        minEndDate?: string | null;
+        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+        page?: number;
+        /** @description Number of results to show */
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Paged_SessionOut_"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
 }

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -4,2158 +4,2360 @@
  */
 
 export interface paths {
-  "/shipments/{shipmentId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Shipment
+         * @description Get shipment data
+         */
+        get: operations["get_shipment_shipments__shipmentId__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Shipment
-     * @description Get shipment data
-     */
-    get: operations["get_shipment_shipments__shipmentId__get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/unassigned": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/unassigned": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Unassigned Items
+         * @description Get unassigned items in shipment
+         */
+        get: operations["get_unassigned_items_shipments__shipmentId__unassigned_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Unassigned Items
-     * @description Get unassigned items in shipment
-     */
-    get: operations["get_unassigned_items_shipments__shipmentId__unassigned_get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/push": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/push": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Push Shipment
+         * @description Push shipment to ISPyB. Unassigned containers (such as a container with no parent top level
+         *     container) are ignored. Unassigned samples are pushed to ISPyB.
+         */
+        post: operations["push_shipment_shipments__shipmentId__push_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Push Shipment
-     * @description Push shipment to ISPyB. Unassigned containers (such as a container with no parent top level
-     *     container) are ignored. Unassigned samples are pushed to ISPyB.
-     */
-    post: operations["push_shipment_shipments__shipmentId__push_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/topLevelContainers": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/topLevelContainers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Top Level Containers
+         * @description Get top level containers in shipment
+         */
+        get: operations["get_top_level_containers_shipments__shipmentId__topLevelContainers_get"];
+        put?: never;
+        /**
+         * Create Top Level Container
+         * @description Create new container in shipment. If the top level container type is 'dewar' and the provided code is
+         *     empty or null, a new one is created.
+         */
+        post: operations["create_top_level_container_shipments__shipmentId__topLevelContainers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Top Level Containers
-     * @description Get top level containers in shipment
-     */
-    get: operations["get_top_level_containers_shipments__shipmentId__topLevelContainers_get"];
-    put?: never;
-    /**
-     * Create Top Level Container
-     * @description Create new container in shipment. If the top level container type is 'dewar' and the provided code is
-     *     empty or null, a new one is created.
-     */
-    post: operations["create_top_level_container_shipments__shipmentId__topLevelContainers_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/containers": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/containers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Container
+         * @description Create new container in shipment
+         */
+        post: operations["create_container_shipments__shipmentId__containers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Create Container
-     * @description Create new container in shipment
-     */
-    post: operations["create_container_shipments__shipmentId__containers_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/samples": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/samples": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Samples
+         * @description Get samples in shipment
+         */
+        get: operations["get_samples_shipments__shipmentId__samples_get"];
+        put?: never;
+        /**
+         * Create Sample
+         * @description Create new sample in shipment
+         */
+        post: operations["create_sample_shipments__shipmentId__samples_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Samples
-     * @description Get samples in shipment
-     */
-    get: operations["get_samples_shipments__shipmentId__samples_get"];
-    put?: never;
-    /**
-     * Create Sample
-     * @description Create new sample in shipment
-     */
-    post: operations["create_sample_shipments__shipmentId__samples_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/request": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/request": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Shipment Request
+         * @description Get shipment request
+         */
+        get: operations["get_shipment_request_shipments__shipmentId__request_get"];
+        put?: never;
+        /**
+         * Create Shipment Request
+         * @description Create new shipment request
+         */
+        post: operations["create_shipment_request_shipments__shipmentId__request_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Shipment Request
-     * @description Get shipment request
-     */
-    get: operations["get_shipment_request_shipments__shipmentId__request_get"];
-    put?: never;
-    /**
-     * Create Shipment Request
-     * @description Create new shipment request
-     */
-    post: operations["create_shipment_request_shipments__shipmentId__request_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/preSession": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/preSession": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Pre Session
+         * @description Create new pre session information
+         */
+        get: operations["get_pre_session_shipments__shipmentId__preSession_get"];
+        /**
+         * Create Pre Session
+         * @description Upsert new pre session information
+         */
+        put: operations["create_pre_session_shipments__shipmentId__preSession_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Pre Session
-     * @description Create new pre session information
-     */
-    get: operations["get_pre_session_shipments__shipmentId__preSession_get"];
-    /**
-     * Create Pre Session
-     * @description Upsert new pre session information
-     */
-    put: operations["create_pre_session_shipments__shipmentId__preSession_put"];
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/tracking-labels": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/tracking-labels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Shipping Labels
+         * @description Get shipping labels for dewar
+         */
+        get: operations["get_shipping_labels_shipments__shipmentId__tracking_labels_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Shipping Labels
-     * @description Get shipping labels for dewar
-     */
-    get: operations["get_shipping_labels_shipments__shipmentId__tracking_labels_get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/update-status": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/update-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update Shipment Status
+         * @description Update shipment status
+         */
+        post: operations["update_shipment_status_shipments__shipmentId__update_status_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Update Shipment Status
-     * @description Update shipment status
-     */
-    post: operations["update_shipment_status_shipments__shipmentId__update_status_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/assign-data-collection-groups": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/assign-data-collection-groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Assign Dcg In Sublocation
+         * @description Update data collection group sample ID in ISPyB. Does not return data.
+         */
+        post: operations["assign_dcg_in_sublocation_shipments__shipmentId__assign_data_collection_groups_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Assign Dcg In Sublocation
-     * @description Update data collection group sample ID in ISPyB. Does not return data.
-     */
-    post: operations["assign_dcg_in_sublocation_shipments__shipmentId__assign_data_collection_groups_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/shipments/{shipmentId}/pdf-report": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/shipments/{shipmentId}/pdf-report": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Pdf Report
+         * @description Get PDF report of shipment
+         */
+        get: operations["get_pdf_report_shipments__shipmentId__pdf_report_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Pdf Report
-     * @description Get PDF report of shipment
-     */
-    get: operations["get_pdf_report_shipments__shipmentId__pdf_report_get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/proposals/{proposalReference}/sessions/{visitNumber}/shipments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/proposals/{proposalReference}/sessions/{visitNumber}/shipments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Shipments
+         * @description Get shipments in session
+         */
+        get: operations["get_shipments_proposals__proposalReference__sessions__visitNumber__shipments_get"];
+        put?: never;
+        /**
+         * Create Shipment
+         * @description Create new shipment in session
+         */
+        post: operations["create_shipment_proposals__proposalReference__sessions__visitNumber__shipments_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Shipments
-     * @description Get shipments in session
-     */
-    get: operations["get_shipments_proposals__proposalReference__sessions__visitNumber__shipments_get"];
-    put?: never;
-    /**
-     * Create Shipment
-     * @description Create new shipment in session
-     */
-    post: operations["create_shipment_proposals__proposalReference__sessions__visitNumber__shipments_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/proposals/{proposalReference}/sessions/{visitNumber}/samples": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/proposals/{proposalReference}/sessions/{visitNumber}/samples": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Samples
+         * @description Get samples in session
+         */
+        get: operations["get_samples_proposals__proposalReference__sessions__visitNumber__samples_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Samples
-     * @description Get samples in session
-     */
-    get: operations["get_samples_proposals__proposalReference__sessions__visitNumber__samples_get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/proposals/{proposalReference}/sessions/{visitNumber}/containers": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/proposals/{proposalReference}/sessions/{visitNumber}/containers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Containers
+         * @description Get containers in session
+         */
+        get: operations["get_containers_proposals__proposalReference__sessions__visitNumber__containers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Containers
-     * @description Get containers in session
-     */
-    get: operations["get_containers_proposals__proposalReference__sessions__visitNumber__containers_get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/proposals/{proposalReference}/data": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/proposals/{proposalReference}/data": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Shipment Data
+         * @description Get lab data for the proposal (lab contacts, proteins...)
+         *
+         *     We can skip auth on this one since it is calling Expeye, and auth is done there
+         */
+        get: operations["get_shipment_data_proposals__proposalReference__data_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Shipment Data
-     * @description Get lab data for the proposal (lab contacts, proteins...)
-     *
-     *     We can skip auth on this one since it is calling Expeye, and auth is done there
-     */
-    get: operations["get_shipment_data_proposals__proposalReference__data_get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/proposals/{proposalReference}/sessions/{visitNumber}/assign-data-collection-groups": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/proposals/{proposalReference}/shipments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Proposal Shipments
+         * @description Get shipments in proposal
+         */
+        get: operations["get_proposal_shipments_proposals__proposalReference__shipments_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Assign Dcg In Sublocation
-     * @description Update data collection group sample ID in ISPyB. Does not return data.
-     */
-    post: operations["assign_dcg_in_sublocation_proposals__proposalReference__sessions__visitNumber__assign_data_collection_groups_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/samples/{sampleId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/proposals/{proposalReference}/sessions/{visitNumber}/assign-data-collection-groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Assign Dcg In Sublocation
+         * @description Update data collection group sample ID in ISPyB. Does not return data.
+         */
+        post: operations["assign_dcg_in_sublocation_proposals__proposalReference__sessions__visitNumber__assign_data_collection_groups_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /**
-     * Delete Sample
-     * @description Create new sample in shipment
-     */
-    delete: operations["delete_sample_samples__sampleId__delete"];
-    options?: never;
-    head?: never;
-    /**
-     * Edit Sample
-     * @description Edit existing sample
-     */
-    patch: operations["edit_sample_samples__sampleId__patch"];
-    trace?: never;
-  };
-  "/containers/{containerId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/samples/{sampleId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Sample
+         * @description Create new sample in shipment
+         */
+        delete: operations["delete_sample_samples__sampleId__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Edit Sample
+         * @description Edit existing sample
+         */
+        patch: operations["edit_sample_samples__sampleId__patch"];
+        trace?: never;
     };
-    /**
-     * Get Container
-     * @description Get container
-     */
-    get: operations["get_container_containers__containerId__get"];
-    put?: never;
-    post?: never;
-    /**
-     * Delete Container
-     * @description Delete container in shipment
-     */
-    delete: operations["delete_container_containers__containerId__delete"];
-    options?: never;
-    head?: never;
-    /**
-     * Edit Container
-     * @description Edit existing container
-     */
-    patch: operations["edit_container_containers__containerId__patch"];
-    trace?: never;
-  };
-  "/topLevelContainers/{topLevelContainerId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/containers/{containerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Container
+         * @description Get container
+         */
+        get: operations["get_container_containers__containerId__get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Container
+         * @description Delete container in shipment
+         */
+        delete: operations["delete_container_containers__containerId__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Edit Container
+         * @description Edit existing container
+         */
+        patch: operations["edit_container_containers__containerId__patch"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /**
-     * Delete Container
-     * @description Create new container in shipment
-     */
-    delete: operations["delete_container_topLevelContainers__topLevelContainerId__delete"];
-    options?: never;
-    head?: never;
-    /**
-     * Edit Container
-     * @description Edit existing container
-     */
-    patch: operations["edit_container_topLevelContainers__topLevelContainerId__patch"];
-    trace?: never;
-  };
-  "/internal-containers": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/topLevelContainers/{topLevelContainerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Container
+         * @description Create new container in shipment
+         */
+        delete: operations["delete_container_topLevelContainers__topLevelContainerId__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Edit Container
+         * @description Edit existing container
+         */
+        patch: operations["edit_container_topLevelContainers__topLevelContainerId__patch"];
+        trace?: never;
     };
-    /**
-     * Get Internal Containers
-     * @description Get internal top level containers
-     */
-    get: operations["get_internal_containers_internal_containers_get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/internal-containers/unassigned": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/internal-containers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Internal Containers
+         * @description Get internal top level containers
+         */
+        get: operations["get_internal_containers_internal_containers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Unassigned Internal Containers
-     * @description Get orphan internal containers
-     */
-    get: operations["get_unassigned_internal_containers_internal_containers_unassigned_get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/internal-containers/containers": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/internal-containers/unassigned": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Unassigned Internal Containers
+         * @description Get orphan internal containers
+         */
+        get: operations["get_unassigned_internal_containers_internal_containers_unassigned_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Create Orphan Container
-     * @description Create orphan container
-     */
-    post: operations["create_orphan_container_internal_containers_containers_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/internal-containers/topLevelContainers": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/internal-containers/containers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Orphan Container
+         * @description Create orphan container
+         */
+        post: operations["create_orphan_container_internal_containers_containers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Create Orphan Top Level Container
-     * @description Create orphan container
-     */
-    post: operations["create_orphan_top_level_container_internal_containers_topLevelContainers_post"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/internal-containers/{topLevelContainerId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/internal-containers/topLevelContainers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Orphan Top Level Container
+         * @description Create orphan container
+         */
+        post: operations["create_orphan_top_level_container_internal_containers_topLevelContainers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get Internal Container
-     * @description Get internal top level container and its children
-     */
-    get: operations["get_internal_container_internal_containers__topLevelContainerId__get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/internal-containers/{topLevelContainerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Internal Container
+         * @description Get internal top level container and its children
+         */
+        get: operations["get_internal_container_internal_containers__topLevelContainerId__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Sessions
+         * @description Get sessions a user can view (wrapper for Expeye endpoint)
+         */
+        get: operations["get_sessions_sessions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    /** ContainerIn */
-    ContainerIn: {
-      /** Toplevelcontainerid */
-      topLevelContainerId?: number | null;
-      /** Parentid */
-      parentId?: number | null;
-      /** Capacity */
-      capacity?: number | null;
-      /** Details */
-      details?: Record<string, never> | null;
-      /** Location */
-      location?: number | null;
-      /**
-       * Requestedreturn
-       * @default false
-       */
-      requestedReturn: boolean | null;
-      /** Registeredcontainer */
-      registeredContainer?: string | null;
-      /** Subtype */
-      subType?: string | null;
-      /**
-       * Name
-       * @description Base container name. If name is not provided, the container's type followedby the container index is used
-       */
-      name?: string | null;
-      /** Comments */
-      comments?: string | null;
-      /** Type */
-      type: string;
-      /**
-       * Isinternal
-       * @default false
-       */
-      isInternal: boolean;
+    schemas: {
+        /** ContainerIn */
+        ContainerIn: {
+            /** Toplevelcontainerid */
+            topLevelContainerId?: number | null;
+            /** Parentid */
+            parentId?: number | null;
+            /** Capacity */
+            capacity?: number | null;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /** Location */
+            location?: number | null;
+            /**
+             * Requestedreturn
+             * @default false
+             */
+            requestedReturn: boolean | null;
+            /** Registeredcontainer */
+            registeredContainer?: string | null;
+            /** Subtype */
+            subType?: string | null;
+            /**
+             * Name
+             * @description Base container name. If name is not provided, the container's type followedby the container index is used
+             */
+            name?: string | null;
+            /** Comments */
+            comments?: string | null;
+            /** Type */
+            type: string;
+            /**
+             * Isinternal
+             * @default false
+             */
+            isInternal: boolean;
+        };
+        /** ContainerOut */
+        ContainerOut: {
+            /** Toplevelcontainerid */
+            topLevelContainerId?: number | null;
+            /** Parentid */
+            parentId?: number | null;
+            /** Capacity */
+            capacity?: number | null;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /** Location */
+            location?: number | null;
+            /**
+             * Requestedreturn
+             * @default false
+             */
+            requestedReturn: boolean | null;
+            /** Registeredcontainer */
+            registeredContainer?: string | null;
+            /** Subtype */
+            subType?: string | null;
+            /**
+             * Name
+             * @description Base container name. If name is not provided, the container's type followedby the container index is used
+             */
+            name?: string | null;
+            /** Comments */
+            comments?: string | null;
+            /** Shipmentid */
+            shipmentId: number;
+            /** Id */
+            id: number;
+            /** Type */
+            type: string;
+            /** Isinternal */
+            isInternal: boolean;
+            /**
+             * Internalstoragecontainer
+             * @description Internal storage container this container is currently in.Only set if this is stored in the facility
+             */
+            internalStorageContainer?: number | null;
+        };
+        /** GenericItem */
+        GenericItem: {
+            /** Id */
+            id: number;
+            /** Name */
+            name: string;
+            data: components["schemas"]["GenericItemData"];
+            /** Children */
+            children?: components["schemas"]["GenericItem"][] | null;
+        };
+        /** GenericItemData */
+        GenericItemData: {
+            /** Type */
+            type: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** HTTPValidationError */
+        HTTPValidationError: {
+            /** Detail */
+            detail?: components["schemas"]["ValidationError"][];
+        };
+        /** OptionalContainer */
+        OptionalContainer: {
+            /** Toplevelcontainerid */
+            topLevelContainerId?: number | null;
+            /** Parentid */
+            parentId?: number | null;
+            /** Capacity */
+            capacity?: number | null;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /** Location */
+            location?: number | null;
+            /**
+             * Requestedreturn
+             * @default false
+             */
+            requestedReturn: boolean | null;
+            /** Registeredcontainer */
+            registeredContainer?: string | null;
+            /** Subtype */
+            subType?: string | null;
+            /**
+             * Name
+             * @description Base container name. If name is not provided, the container's type followedby the container index is used
+             */
+            name?: string | null;
+            /** Comments */
+            comments?: string | null;
+            /** Type */
+            type?: string | null;
+            /** Shipmentid */
+            shipmentId?: number | null;
+            /** Isinternal */
+            isInternal?: boolean | null;
+        };
+        /** OptionalSample */
+        OptionalSample: {
+            /** Containerid */
+            containerId?: number | null;
+            /** Location */
+            location?: number | null;
+            /** Sublocation */
+            subLocation?: number | null;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /** Comments */
+            comments?: string | null;
+            /**
+             * Name
+             * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
+             */
+            name?: string | null;
+            /** Proteinid */
+            proteinId?: number | null;
+            /** Type */
+            type?: string | null;
+            /** Shipmentid */
+            shipmentId?: number | null;
+        };
+        /** OptionalTopLevelContainer */
+        OptionalTopLevelContainer: {
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /** Comments */
+            comments?: string | null;
+            /**
+             * Name
+             * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
+             */
+            name?: string | null;
+            /** Type */
+            type?: string | null;
+            /** Code */
+            code?: string | null;
+            /** Barcode */
+            barCode?: string | null;
+        };
+        /** Paged[ContainerOut] */
+        Paged_ContainerOut_: {
+            /** Items */
+            items: components["schemas"]["ContainerOut"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Limit */
+            limit: number;
+        };
+        /** Paged[GenericItem] */
+        Paged_GenericItem_: {
+            /** Items */
+            items: components["schemas"]["GenericItem"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Limit */
+            limit: number;
+        };
+        /** Paged[SampleOut] */
+        Paged_SampleOut_: {
+            /** Items */
+            items: components["schemas"]["SampleOut"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Limit */
+            limit: number;
+        };
+        /** Paged[SessionOut] */
+        Paged_SessionOut_: {
+            /** Items */
+            items: components["schemas"]["SessionOut"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Limit */
+            limit: number;
+        };
+        /** Paged[ShipmentOut] */
+        Paged_ShipmentOut_: {
+            /** Items */
+            items: components["schemas"]["ShipmentOut"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Limit */
+            limit: number;
+        };
+        /** Paged[TopLevelContainerOut] */
+        Paged_TopLevelContainerOut_: {
+            /** Items */
+            items: components["schemas"]["TopLevelContainerOut"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Limit */
+            limit: number;
+        };
+        /** PreSessionIn */
+        PreSessionIn: {
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** PreSessionOut */
+        PreSessionOut: {
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Islocked
+             * @default false
+             */
+            isLocked: boolean;
+        };
+        /** SampleIn */
+        SampleIn: {
+            /** Containerid */
+            containerId?: number | null;
+            /** Location */
+            location?: number | null;
+            /** Sublocation */
+            subLocation?: number | null;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /** Comments */
+            comments?: string | null;
+            /**
+             * Name
+             * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
+             */
+            name?: string | null;
+            /** Proteinid */
+            proteinId: number;
+            /** Type */
+            type?: string | null;
+            /**
+             * Copies
+             * @default 1
+             */
+            copies: number;
+            /** Parents */
+            parents?: number[] | null;
+        };
+        /** SampleOut */
+        SampleOut: {
+            /** Containerid */
+            containerId?: number | null;
+            /** Location */
+            location?: number | null;
+            /** Sublocation */
+            subLocation?: number | null;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /** Comments */
+            comments?: string | null;
+            /**
+             * Name
+             * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
+             */
+            name?: string | null;
+            /** Id */
+            id: number;
+            /** Shipmentid */
+            shipmentId: number;
+            /** Proteinid */
+            proteinId: number;
+            /** Containername */
+            containerName?: string | null;
+            /** Type */
+            type: string;
+            /** Datacollectiongroupid */
+            dataCollectionGroupId?: number | null;
+            /** Parentshipmentname */
+            parentShipmentName?: string | null;
+            /** Originsamples */
+            originSamples?: components["schemas"]["SampleOut"][] | null;
+            /** Derivedsamples */
+            derivedSamples?: components["schemas"]["SampleOut"][] | null;
+            /** Externalid */
+            externalId?: number | null;
+        };
+        /** SessionOut */
+        SessionOut: {
+            /** Beamlinesetupid */
+            beamLineSetupId?: number | null;
+            /** Beamcalendarid */
+            beamCalendarId?: number | null;
+            /** Startdate */
+            startDate?: string | null;
+            /** Enddate */
+            endDate?: string | null;
+            /** Beamlinename */
+            beamLineName?: string | null;
+            /** Scheduled */
+            scheduled?: number | null;
+            /** Nbshifts */
+            nbShifts?: number | null;
+            /** Comments */
+            comments?: string | null;
+            /** Visitnumber */
+            visitNumber?: number | null;
+            /**
+             * Usedflag
+             * @description Indicates if session has Datacollections or XFE or EnergyScans attached
+             */
+            usedFlag?: number | null;
+            /**
+             * Lastupdate
+             * @description Last update timestamp: by default the end of the session, the last collect
+             */
+            lastUpdate?: string | null;
+            /** Parentproposal */
+            parentProposal?: string | null;
+            /**
+             * Proposalid
+             * @description Proposal ID
+             */
+            proposalId: number;
+            /**
+             * Sessionid
+             * @description Session ID
+             */
+            sessionId: number;
+            /** Beamlineoperator */
+            beamLineOperator?: string[] | null;
+            /**
+             * Bltimestamp
+             * Format: date-time
+             */
+            bltimeStamp: string;
+            /** Purgedprocesseddata */
+            purgedProcessedData: boolean;
+            /**
+             * Archived
+             * @description The data for the session is archived and no longer available on disk
+             */
+            archived: number;
+            /** Collectiongroups */
+            collectionGroups?: number | null;
+        };
+        /** ShipmentChildren */
+        ShipmentChildren: {
+            /** Id */
+            id: number;
+            /** Name */
+            name: string;
+            /** Children */
+            children: components["schemas"]["GenericItem"][];
+            /** Data */
+            data: {
+                [key: string]: unknown;
+            };
+        };
+        /** ShipmentIn */
+        ShipmentIn: {
+            /** Name */
+            name: string;
+            /** Comments */
+            comments?: string | null;
+        };
+        /** ShipmentOut */
+        ShipmentOut: {
+            /** Id */
+            id: number;
+            /** Proposalcode */
+            proposalCode: string;
+            /** Proposalnumber */
+            proposalNumber: number;
+            /** Visitnumber */
+            visitNumber: number;
+            /** Name */
+            name: string;
+            /** Comments */
+            comments?: string | null;
+            /** Creationdate */
+            creationDate: string | null;
+            /** Status */
+            status?: string | null;
+            /** Shipmentrequest */
+            shipmentRequest?: number | null;
+            /**
+             * Laststatusupdate
+             * Format: date-time
+             */
+            lastStatusUpdate: string;
+            /** Externalid */
+            externalId?: number | null;
+        };
+        /** StatusUpdate */
+        StatusUpdate: {
+            /** Origin Url */
+            origin_url: string;
+            /** Journey Type */
+            journey_type: string;
+            /** Status */
+            status: string;
+            /** Tracking Number */
+            tracking_number: string;
+            /** Pickup Confirmation Code */
+            pickup_confirmation_code?: string | null;
+            /** Pickup Confirmation Timestamp */
+            pickup_confirmation_timestamp: string | null;
+        };
+        /** SublocationAssignment */
+        SublocationAssignment: {
+            /** Sublocation */
+            subLocation: number;
+            /** Datacollectiongroupid */
+            dataCollectionGroupId: number;
+        };
+        /** TopLevelContainerHistory */
+        TopLevelContainerHistory: {
+            /** Storagelocation */
+            storageLocation?: string | null;
+            /** Dewarid */
+            dewarId: number;
+            /** Dewarstatus */
+            dewarStatus: string;
+            /** Arrivaldate */
+            arrivalDate?: string | null;
+        };
+        /** TopLevelContainerIn */
+        TopLevelContainerIn: {
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /** Comments */
+            comments?: string | null;
+            /**
+             * Name
+             * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
+             */
+            name?: string | null;
+            /** Type */
+            type: string;
+            /** Code */
+            code?: string | null;
+            /**
+             * Isinternal
+             * @default false
+             */
+            isInternal: boolean;
+        };
+        /** TopLevelContainerOut */
+        TopLevelContainerOut: {
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+            /** Comments */
+            comments?: string | null;
+            /**
+             * Name
+             * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
+             */
+            name?: string | null;
+            /** Id */
+            id: number;
+            /** Type */
+            type: string;
+            /** Externalid */
+            externalId?: number | null;
+            /** Barcode */
+            barCode?: string | null;
+            /** History */
+            history?: components["schemas"]["TopLevelContainerHistory"][] | null;
+        };
+        /** UnassignedItems */
+        UnassignedItems: {
+            /** Samples */
+            samples: components["schemas"]["GenericItem"][];
+            /** Gridboxes */
+            gridBoxes: components["schemas"]["GenericItem"][];
+            /** Containers */
+            containers: components["schemas"]["GenericItem"][];
+        };
+        /** ValidationError */
+        ValidationError: {
+            /** Location */
+            loc: (string | number)[];
+            /** Message */
+            msg: string;
+            /** Error Type */
+            type: string;
+        };
     };
-    /** ContainerOut */
-    ContainerOut: {
-      /** Toplevelcontainerid */
-      topLevelContainerId?: number | null;
-      /** Parentid */
-      parentId?: number | null;
-      /** Capacity */
-      capacity?: number | null;
-      /** Details */
-      details?: Record<string, never> | null;
-      /** Location */
-      location?: number | null;
-      /**
-       * Requestedreturn
-       * @default false
-       */
-      requestedReturn: boolean | null;
-      /** Registeredcontainer */
-      registeredContainer?: string | null;
-      /** Subtype */
-      subType?: string | null;
-      /**
-       * Name
-       * @description Base container name. If name is not provided, the container's type followedby the container index is used
-       */
-      name?: string | null;
-      /** Comments */
-      comments?: string | null;
-      /** Shipmentid */
-      shipmentId: number;
-      /** Id */
-      id: number;
-      /** Type */
-      type: string;
-      /** Isinternal */
-      isInternal: boolean;
-      /**
-       * Internalstoragecontainer
-       * @description Internal storage container this container is currently in.Only set if this is stored in the facility
-       */
-      internalStorageContainer?: number | null;
-    };
-    /** GenericItem */
-    GenericItem: {
-      /** Id */
-      id: number;
-      /** Name */
-      name: string;
-      data: components["schemas"]["GenericItemData"];
-      /** Children */
-      children?: components["schemas"]["GenericItem"][] | null;
-    };
-    /** GenericItemData */
-    GenericItemData: {
-      /** Type */
-      type: string;
-    } & {
-      [key: string]: unknown;
-    };
-    /** HTTPValidationError */
-    HTTPValidationError: {
-      /** Detail */
-      detail?: components["schemas"]["ValidationError"][];
-    };
-    /** OptionalContainer */
-    OptionalContainer: {
-      /** Toplevelcontainerid */
-      topLevelContainerId?: number | null;
-      /** Parentid */
-      parentId?: number | null;
-      /** Capacity */
-      capacity?: number | null;
-      /** Details */
-      details?: Record<string, never> | null;
-      /** Location */
-      location?: number | null;
-      /**
-       * Requestedreturn
-       * @default false
-       */
-      requestedReturn: boolean | null;
-      /** Registeredcontainer */
-      registeredContainer?: string | null;
-      /** Subtype */
-      subType?: string | null;
-      /**
-       * Name
-       * @description Base container name. If name is not provided, the container's type followedby the container index is used
-       */
-      name?: string | null;
-      /** Comments */
-      comments?: string | null;
-      /** Type */
-      type?: string | null;
-      /** Shipmentid */
-      shipmentId?: number | null;
-      /** Isinternal */
-      isInternal?: boolean | null;
-    };
-    /** OptionalSample */
-    OptionalSample: {
-      /** Containerid */
-      containerId?: number | null;
-      /** Location */
-      location?: number | null;
-      /** Sublocation */
-      subLocation?: number | null;
-      /** Details */
-      details?: Record<string, never> | null;
-      /** Comments */
-      comments?: string | null;
-      /**
-       * Name
-       * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
-       */
-      name?: string | null;
-      /** Proteinid */
-      proteinId?: number | null;
-      /** Type */
-      type?: string | null;
-      /** Shipmentid */
-      shipmentId?: number | null;
-    };
-    /** OptionalTopLevelContainer */
-    OptionalTopLevelContainer: {
-      /** Details */
-      details?: Record<string, never> | null;
-      /** Comments */
-      comments?: string | null;
-      /**
-       * Name
-       * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
-       */
-      name?: string | null;
-      /** Type */
-      type?: string | null;
-      /** Code */
-      code?: string | null;
-      /** Barcode */
-      barCode?: string | null;
-    };
-    /** Paged[ContainerOut] */
-    Paged_ContainerOut_: {
-      /** Items */
-      items: components["schemas"]["ContainerOut"][];
-      /** Total */
-      total: number;
-      /** Page */
-      page: number;
-      /** Limit */
-      limit: number;
-    };
-    /** Paged[GenericItem] */
-    Paged_GenericItem_: {
-      /** Items */
-      items: components["schemas"]["GenericItem"][];
-      /** Total */
-      total: number;
-      /** Page */
-      page: number;
-      /** Limit */
-      limit: number;
-    };
-    /** Paged[SampleOut] */
-    Paged_SampleOut_: {
-      /** Items */
-      items: components["schemas"]["SampleOut"][];
-      /** Total */
-      total: number;
-      /** Page */
-      page: number;
-      /** Limit */
-      limit: number;
-    };
-    /** Paged[ShipmentOut] */
-    Paged_ShipmentOut_: {
-      /** Items */
-      items: components["schemas"]["ShipmentOut"][];
-      /** Total */
-      total: number;
-      /** Page */
-      page: number;
-      /** Limit */
-      limit: number;
-    };
-    /** Paged[TopLevelContainerOut] */
-    Paged_TopLevelContainerOut_: {
-      /** Items */
-      items: components["schemas"]["TopLevelContainerOut"][];
-      /** Total */
-      total: number;
-      /** Page */
-      page: number;
-      /** Limit */
-      limit: number;
-    };
-    /** PreSessionIn */
-    PreSessionIn: {
-      /** Details */
-      details?: Record<string, never> | null;
-    };
-    /** PreSessionOut */
-    PreSessionOut: {
-      /** Details */
-      details?: Record<string, never> | null;
-      /**
-       * Islocked
-       * @default false
-       */
-      isLocked: boolean;
-    };
-    /** SampleIn */
-    SampleIn: {
-      /** Containerid */
-      containerId?: number | null;
-      /** Location */
-      location?: number | null;
-      /** Sublocation */
-      subLocation?: number | null;
-      /** Details */
-      details?: Record<string, never> | null;
-      /** Comments */
-      comments?: string | null;
-      /**
-       * Name
-       * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
-       */
-      name?: string | null;
-      /** Proteinid */
-      proteinId: number;
-      /** Type */
-      type?: string | null;
-      /**
-       * Copies
-       * @default 1
-       */
-      copies: number;
-      /** Parents */
-      parents?: number[] | null;
-    };
-    /** SampleOut */
-    SampleOut: {
-      /** Containerid */
-      containerId?: number | null;
-      /** Location */
-      location?: number | null;
-      /** Sublocation */
-      subLocation?: number | null;
-      /** Details */
-      details?: Record<string, any> | null;
-      /** Comments */
-      comments?: string | null;
-      /**
-       * Name
-       * @description Sample name, if not provided, the provided protein's name followed by the sample index is used
-       */
-      name?: string | null;
-      /** Id */
-      id: number;
-      /** Shipmentid */
-      shipmentId: number;
-      /** Proteinid */
-      proteinId: number;
-      /** Containername */
-      containerName?: string | null;
-      /** Type */
-      type: string;
-      /** Datacollectiongroupid */
-      dataCollectionGroupId?: number | null;
-      /** Parentshipmentname */
-      parentShipmentName?: string | null;
-      /** Originsamples */
-      originSamples?: components["schemas"]["SampleOut"][] | null;
-      /** Derivedsamples */
-      derivedSamples?: components["schemas"]["SampleOut"][] | null;
-      /** Externalid */
-      externalId?: number | null;
-    };
-    /** ShipmentChildren */
-    ShipmentChildren: {
-      /** Id */
-      id: number;
-      /** Name */
-      name: string;
-      /** Children */
-      children: components["schemas"]["GenericItem"][];
-      /** Data */
-      data: Record<string, never>;
-    };
-    /** ShipmentIn */
-    ShipmentIn: {
-      /** Name */
-      name: string;
-      /** Comments */
-      comments?: string | null;
-    };
-    /** ShipmentOut */
-    ShipmentOut: {
-      /** Id */
-      id: number;
-      /** Proposalcode */
-      proposalCode: string;
-      /** Proposalnumber */
-      proposalNumber: number;
-      /** Visitnumber */
-      visitNumber: number;
-      /** Name */
-      name: string;
-      /** Comments */
-      comments?: string | null;
-      /** Creationdate */
-      creationDate: string | null;
-      /** Status */
-      status?: string | null;
-      /** Shipmentrequest */
-      shipmentRequest?: number | null;
-      /**
-       * Laststatusupdate
-       * Format: date-time
-       */
-      lastStatusUpdate: string;
-      /** Externalid */
-      externalId?: number | null;
-    };
-    /** StatusUpdate */
-    StatusUpdate: {
-      /** Origin Url */
-      origin_url: string;
-      /** Journey Type */
-      journey_type: string;
-      /** Status */
-      status: string;
-      /** Tracking Number */
-      tracking_number: string;
-      /** Pickup Confirmation Code */
-      pickup_confirmation_code?: string | null;
-      /** Pickup Confirmation Timestamp */
-      pickup_confirmation_timestamp: string | null;
-    };
-    /** SublocationAssignment */
-    SublocationAssignment: {
-      /** Sublocation */
-      subLocation: number;
-      /** Datacollectiongroupid */
-      dataCollectionGroupId: number;
-    };
-    /** TopLevelContainerHistory */
-    TopLevelContainerHistory: {
-      /** Storagelocation */
-      storageLocation?: string | null;
-      /** Dewarid */
-      dewarId: number;
-      /** Dewarstatus */
-      dewarStatus: string;
-      /** Arrivaldate */
-      arrivalDate?: string | null;
-    };
-    /** TopLevelContainerIn */
-    TopLevelContainerIn: {
-      /** Details */
-      details?: Record<string, never> | null;
-      /** Comments */
-      comments?: string | null;
-      /**
-       * Name
-       * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
-       */
-      name?: string | null;
-      /** Type */
-      type: string;
-      /** Code */
-      code?: string | null;
-      /**
-       * Isinternal
-       * @default false
-       */
-      isInternal: boolean;
-    };
-    /** TopLevelContainerOut */
-    TopLevelContainerOut: {
-      /** Details */
-      details?: Record<string, never> | null;
-      /** Comments */
-      comments?: string | null;
-      /**
-       * Name
-       * @description Base top level container name. If name is not provided, the container's type followedby the container index is used
-       */
-      name?: string | null;
-      /** Id */
-      id: number;
-      /** Type */
-      type: string;
-      /** Externalid */
-      externalId?: number | null;
-      /**
-       * Barcode
-       * Format: uuid
-       */
-      barCode: string;
-      /** History */
-      history?: components["schemas"]["TopLevelContainerHistory"][] | null;
-    };
-    /** UnassignedItems */
-    UnassignedItems: {
-      /** Samples */
-      samples: components["schemas"]["GenericItem"][];
-      /** Gridboxes */
-      gridBoxes: components["schemas"]["GenericItem"][];
-      /** Containers */
-      containers: components["schemas"]["GenericItem"][];
-    };
-    /** ValidationError */
-    ValidationError: {
-      /** Location */
-      loc: (string | number)[];
-      /** Message */
-      msg: string;
-      /** Error Type */
-      type: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  get_shipment_shipments__shipmentId__get: {
-    parameters: {
-      query?: {
-        /** @description Whether to get children as part of the request */
-        getChildren?: boolean;
-      };
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ShipmentChildren"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_unassigned_items_shipments__shipmentId__unassigned_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["UnassignedItems"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  push_shipment_shipments__shipmentId__push_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_top_level_containers_shipments__shipmentId__topLevelContainers_get: {
-    parameters: {
-      query?: {
-        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-        page?: number;
-        /** @description Number of results to show */
-        limit?: number;
-      };
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Paged_TopLevelContainerOut_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  create_top_level_container_shipments__shipmentId__topLevelContainers_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["TopLevelContainerIn"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TopLevelContainerOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  create_container_shipments__shipmentId__containers_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ContainerIn"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ContainerOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_samples_shipments__shipmentId__samples_get: {
-    parameters: {
-      query?: {
-        ignoreExternal?: boolean;
-        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-        page?: number;
-        /** @description Number of results to show */
-        limit?: number;
-      };
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Paged_SampleOut_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  create_sample_shipments__shipmentId__samples_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SampleIn"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Paged_SampleOut_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_shipment_request_shipments__shipmentId__request_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      307: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  create_shipment_request_shipments__shipmentId__request_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ShipmentOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_pre_session_shipments__shipmentId__preSession_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["PreSessionOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  create_pre_session_shipments__shipmentId__preSession_put: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PreSessionIn"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["PreSessionOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_shipping_labels_shipments__shipmentId__tracking_labels_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": unknown;
-          "application/pdf": unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  update_shipment_status_shipments__shipmentId__update_status_post: {
-    parameters: {
-      query: {
-        token: string;
-      };
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["StatusUpdate"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ShipmentOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  assign_dcg_in_sublocation_shipments__shipmentId__assign_data_collection_groups_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SublocationAssignment"][];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_pdf_report_shipments__shipmentId__pdf_report_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        shipmentId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_shipments_proposals__proposalReference__sessions__visitNumber__shipments_get: {
-    parameters: {
-      query?: {
-        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-        page?: number;
-        /** @description Number of results to show */
-        limit?: number;
-      };
-      header?: never;
-      path: {
-        proposalReference: string;
-        visitNumber: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Paged_ShipmentOut_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  create_shipment_proposals__proposalReference__sessions__visitNumber__shipments_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        proposalReference: string;
-        visitNumber: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ShipmentIn"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ShipmentOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_samples_proposals__proposalReference__sessions__visitNumber__samples_get: {
-    parameters: {
-      query?: {
-        ignoreExternal?: boolean;
-        internalOnly?: boolean;
-        ignoreInternal?: boolean;
-        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-        page?: number;
-        /** @description Number of results to show */
-        limit?: number;
-      };
-      header?: never;
-      path: {
-        proposalReference: string;
-        visitNumber: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Paged_SampleOut_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_containers_proposals__proposalReference__sessions__visitNumber__containers_get: {
-    parameters: {
-      query?: {
-        /** @description Only display containers assigned to internal containers */
-        isInternal?: boolean;
-        /** @description Container type to filter by */
-        type?: string;
-        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-        page?: number;
-        /** @description Number of results to show */
-        limit?: number;
-      };
-      header?: never;
-      path: {
-        proposalReference: string;
-        visitNumber: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Paged_ContainerOut_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_shipment_data_proposals__proposalReference__data_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        proposalReference: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  assign_dcg_in_sublocation_proposals__proposalReference__sessions__visitNumber__assign_data_collection_groups_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        proposalReference: string;
-        visitNumber: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SublocationAssignment"][];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  delete_sample_samples__sampleId__delete: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        sampleId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  edit_sample_samples__sampleId__patch: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        sampleId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["OptionalSample"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SampleOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_container_containers__containerId__get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        containerId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ContainerOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  delete_container_containers__containerId__delete: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        containerId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  edit_container_containers__containerId__patch: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        containerId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["OptionalContainer"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ContainerOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  delete_container_topLevelContainers__topLevelContainerId__delete: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        topLevelContainerId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  edit_container_topLevelContainers__topLevelContainerId__patch: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        topLevelContainerId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["OptionalTopLevelContainer"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TopLevelContainerOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_internal_containers_internal_containers_get: {
-    parameters: {
-      query?: {
-        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-        page?: number;
-        /** @description Number of results to show */
-        limit?: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Paged_TopLevelContainerOut_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_unassigned_internal_containers_internal_containers_unassigned_get: {
-    parameters: {
-      query?: {
-        /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
-        page?: number;
-        /** @description Number of results to show */
-        limit?: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Paged_GenericItem_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  create_orphan_container_internal_containers_containers_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ContainerIn"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ContainerOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  create_orphan_top_level_container_internal_containers_topLevelContainers_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["TopLevelContainerIn"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TopLevelContainerOut"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  get_internal_container_internal_containers__topLevelContainerId__get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        topLevelContainerId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ShipmentChildren"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
+    get_shipment_shipments__shipmentId__get: {
+        parameters: {
+            query?: {
+                /** @description Whether to get children as part of the request */
+                getChildren?: boolean;
+            };
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShipmentChildren"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_unassigned_items_shipments__shipmentId__unassigned_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnassignedItems"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    push_shipment_shipments__shipmentId__push_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_top_level_containers_shipments__shipmentId__topLevelContainers_get: {
+        parameters: {
+            query?: {
+                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+                page?: number;
+                /** @description Number of results to show */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paged_TopLevelContainerOut_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_top_level_container_shipments__shipmentId__topLevelContainers_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TopLevelContainerIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopLevelContainerOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_container_shipments__shipmentId__containers_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ContainerIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_samples_shipments__shipmentId__samples_get: {
+        parameters: {
+            query?: {
+                ignoreExternal?: boolean;
+                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+                page?: number;
+                /** @description Number of results to show */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paged_SampleOut_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_sample_shipments__shipmentId__samples_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SampleIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paged_SampleOut_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_shipment_request_shipments__shipmentId__request_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            307: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_shipment_request_shipments__shipmentId__request_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShipmentOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_pre_session_shipments__shipmentId__preSession_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PreSessionOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_pre_session_shipments__shipmentId__preSession_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PreSessionIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PreSessionOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_shipping_labels_shipments__shipmentId__tracking_labels_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    "application/pdf": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_shipment_status_shipments__shipmentId__update_status_post: {
+        parameters: {
+            query: {
+                token: string;
+            };
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StatusUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShipmentOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    assign_dcg_in_sublocation_shipments__shipmentId__assign_data_collection_groups_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SublocationAssignment"][];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_pdf_report_shipments__shipmentId__pdf_report_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                shipmentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_shipments_proposals__proposalReference__sessions__visitNumber__shipments_get: {
+        parameters: {
+            query?: {
+                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+                page?: number;
+                /** @description Number of results to show */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                proposalReference: string;
+                visitNumber: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paged_ShipmentOut_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_shipment_proposals__proposalReference__sessions__visitNumber__shipments_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                proposalReference: string;
+                visitNumber: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ShipmentIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShipmentOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_samples_proposals__proposalReference__sessions__visitNumber__samples_get: {
+        parameters: {
+            query?: {
+                ignoreExternal?: boolean;
+                internalOnly?: boolean;
+                ignoreInternal?: boolean;
+                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+                page?: number;
+                /** @description Number of results to show */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                proposalReference: string;
+                visitNumber: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paged_SampleOut_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_containers_proposals__proposalReference__sessions__visitNumber__containers_get: {
+        parameters: {
+            query?: {
+                /** @description Only display containers assigned to internal containers */
+                isInternal?: boolean;
+                /** @description Container type to filter by */
+                type?: string;
+                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+                page?: number;
+                /** @description Number of results to show */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                proposalReference: string;
+                visitNumber: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paged_ContainerOut_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_shipment_data_proposals__proposalReference__data_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                proposalReference: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_proposal_shipments_proposals__proposalReference__shipments_get: {
+        parameters: {
+            query?: {
+                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+                page?: number;
+                /** @description Number of results to show */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                proposalReference: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    assign_dcg_in_sublocation_proposals__proposalReference__sessions__visitNumber__assign_data_collection_groups_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                proposalReference: string;
+                visitNumber: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SublocationAssignment"][];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_sample_samples__sampleId__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sampleId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    edit_sample_samples__sampleId__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sampleId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OptionalSample"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SampleOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_container_containers__containerId__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                containerId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_container_containers__containerId__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                containerId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    edit_container_containers__containerId__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                containerId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OptionalContainer"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_container_topLevelContainers__topLevelContainerId__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topLevelContainerId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    edit_container_topLevelContainers__topLevelContainerId__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topLevelContainerId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OptionalTopLevelContainer"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopLevelContainerOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_internal_containers_internal_containers_get: {
+        parameters: {
+            query?: {
+                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+                page?: number;
+                /** @description Number of results to show */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paged_TopLevelContainerOut_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_unassigned_internal_containers_internal_containers_unassigned_get: {
+        parameters: {
+            query?: {
+                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+                page?: number;
+                /** @description Number of results to show */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paged_GenericItem_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_orphan_container_internal_containers_containers_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ContainerIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContainerOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_orphan_top_level_container_internal_containers_topLevelContainers_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TopLevelContainerIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopLevelContainerOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_internal_container_internal_containers__topLevelContainerId__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topLevelContainerId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShipmentChildren"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_sessions_sessions_get: {
+        parameters: {
+            query?: {
+                minEndDate?: string | null;
+                /** @description Page number/Results to skip. Negative numbers count backwards from the last page */
+                page?: number;
+                /** @description Number of results to show */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paged_SessionOut_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
 }

--- a/src/utils/generic.tsx
+++ b/src/utils/generic.tsx
@@ -141,7 +141,9 @@ export const parseNetworkError = (response?: Record<string, any>) => {
  * @param dateString Original date string
  * @returns Human readable date string
  */
-export const formatDate = (dateString: string) => {
-  const options = { year: "numeric", month: "long", day: "numeric" };
+export const formatDate = (dateString: string | null | undefined) => {
+  if (!dateString) {
+    return "?" 
+  }
   return new Date(dateString).toLocaleString("en-GB");
 };

--- a/src/utils/generic.tsx
+++ b/src/utils/generic.tsx
@@ -143,7 +143,7 @@ export const parseNetworkError = (response?: Record<string, any>) => {
  */
 export const formatDate = (dateString: string | null | undefined) => {
   if (!dateString) {
-    return "?" 
+    return "?";
   }
   return new Date(dateString).toLocaleString("en-GB");
 };


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1879](https://jira.diamond.ac.uk/browse/LIMS-1879)

**Summary**:

New page displaying all sample collections for a given proposal, as well as new "shortcut" links to the most recent sessions in the front page

**Changes**:
- Add session shortcut links to frontpage
- Add page displaying all sample collections for a given proposal

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/, check if current/upcoming sessions are displayed
<img width="1705" height="982" alt="image" src="https://github.com/user-attachments/assets/61df1134-0611-4257-9f69-311831b2c44d" />
- Click "view session overview" for any of them, check if you're sent to the "session samples dashboard" page
- Click "view proposal overview" for any of them, check if you're sent to the "Proposal Sample Collections" page
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/shipments, check if 5 shipments are displayed
- Check if you're taken to the "session samples dashboard" page whenever you click the session number
- Check if you're taken to the sample collection whenever you click the "view sample collection" button