### PR TITLE
Remove international shipping message

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/submitted/page.tsx
@@ -128,16 +128,6 @@ const SubmissionOverview = async (props: { params: Promise<ShipmentParams> }) =>
               Tracking labels <b>must</b> be securely affixed to the outside of both dewars and
               dewar cases, even if using your own courier.
             </Text>
-            <Alert status='info' variant='info'>
-              <AlertIcon />
-              <AlertDescription>
-                If your shipment originates from outside the UK, and you plan to ship through
-                Diamond, email eBIC support at{" "}
-                <Link href={`mailto:${process.env.CONTACT_EMAIL}`}>
-                  {process.env.CONTACT_EMAIL}
-                </Link>
-              </AlertDescription>
-            </Alert>
             <HStack>
               <ArrangeShipmentButton params={params} isBooked={shipmentData.isBooked} />
               <Button


### PR DESCRIPTION
**Summary**:

Since Matt's shipping service now supports international shipments, we must remove the message

**Changes**:
- Remove international shipping message

**To test**:
- Go to /proposals/bi23047/sessions/100/shipments/117/submitted, check the page no longer has this message
<img width="1550" height="355" alt="image" src="https://github.com/user-attachments/assets/c548a1fe-70d7-4b2b-a2d4-5caff07e5dc1" />
