### PR TITLE
Set explicit name length limit

### DIFF
--- a/src/utils/generic.tsx
+++ b/src/utils/generic.tsx
@@ -103,6 +103,7 @@ export const pascalToSpace = (input: string) =>
   input.replace(/([A-Z])/g, " $1").replace(/^./, (str) => str.toUpperCase());
 
 export const nameValidation = {
+  maxLength: 80,
   pattern: {
     value: /^[a-zA-Z0-9_]*$/,
     message: "Name must only contain alphanumeric characters and underscores",


### PR DESCRIPTION
**Summary**:

To make errors clearer, forms are now pre-validated with an explicit name length limit

**Changes**:
- Set explicit name length limit

**To test**:
- Go to a page that allows you to set names, such as https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/gridBox/new/edit
- Check that if you set a name longer than 80 characters, an error is displayed
