### PR TITLE
[LIMS-2066] More descriptive error message for sample with parent/child

### DIFF
--- a/src/components/visualisation/ShipmentOverview.test.tsx
+++ b/src/components/visualisation/ShipmentOverview.test.tsx
@@ -12,7 +12,7 @@ const defaultShipment = [
     id: "dewar",
     name: "dewar",
     data: { type: "dewar" },
-    children: [puck],
+    children: [{ ...puck, data: { topLevelContainerId: 1 } }],
   },
 ] satisfies TreeData<BaseShipmentItem>[];
 
@@ -55,9 +55,9 @@ describe("Sample Collection Overview", () => {
 
     screen.getByText("dewar");
 
-    fireEvent.click(screen.getAllByText("Remove")[0]);
+    fireEvent.click(screen.getAllByText("Delete")[0]);
     await waitFor(() =>
-      expect(toastMock).toHaveBeenCalledWith({ title: "Successfully removed item!" }),
+      expect(toastMock).toHaveBeenCalledWith({ title: "Successfully deleted item!" }),
     );
   });
 
@@ -129,9 +129,9 @@ describe("Sample Collection Overview", () => {
       },
     });
 
-    fireEvent.click(screen.getByText("Remove"));
+    fireEvent.click(screen.getByText("Delete"));
     await waitFor(() =>
-      expect(toastMock).toHaveBeenCalledWith({ title: "Successfully removed item!" }),
+      expect(toastMock).toHaveBeenCalledWith({ title: "Successfully deleted item!" }),
     );
   });
 });

--- a/src/components/visualisation/ShipmentOverview.tsx
+++ b/src/components/visualisation/ShipmentOverview.tsx
@@ -33,16 +33,20 @@ export const ShipmentOverview = ({
           ? { containerId: null, location: null }
           : { topLevelContainerId: null, parentId: null, location: null };
 
-      await Item.patch(item.id, body, endpoint);
-      toast({ title: "Successfully unassigned item!" });
+      const updatedItem = await Item.patch(item.id, body, endpoint);
+      if (updatedItem !== undefined) {
+        toast({ title: "Successfully unassigned item!" });
+      }
     },
     [toast],
   );
 
   const deleteItem = useCallback(
     async (item: TreeData<BaseShipmentItem>, endpoint: Step["endpoint"]) => {
-      await Item.delete(item.id, endpoint);
-      toast({ title: "Successfully removed item!" });
+      const status = await Item.delete(item.id, endpoint);
+      if (status?.status === "OK") {
+        toast({ title: "Successfully deleted item!" });
+      }
     },
     [toast],
   );
@@ -52,9 +56,9 @@ export const ShipmentOverview = ({
     const endpoint = steps[getCurrentStepIndex(item.data.type)].endpoint;
 
     if (endpoint === "topLevelContainers") {
-      deleteItem(item, endpoint);
+      await deleteItem(item, endpoint);
     } else {
-      unassignItem(item, endpoint);
+      await unassignItem(item, endpoint);
     }
   };
 
@@ -63,7 +67,7 @@ export const ShipmentOverview = ({
     async (item: TreeData<BaseShipmentItem>) => {
       const endpoint = steps[getCurrentStepIndex(item.data.type)].endpoint;
       if (item.data.containerId || item.data.parentId || item.data.topLevelContainerId) {
-        unassignItem(item, endpoint);
+        await unassignItem(item, endpoint);
       } else {
         await deleteItem(item, endpoint);
       }

--- a/src/components/visualisation/treeView.test.tsx
+++ b/src/components/visualisation/treeView.test.tsx
@@ -11,7 +11,7 @@ describe("Tree View", () => {
   });
 
   it("should render remove/edit buttons by default", () => {
-    render(<TreeView data={[{ id: "1", name: "Test", data: {} }]} />);
+    render(<TreeView data={[{ id: "1", name: "Test", data: { parentId: 1 } }]} />);
 
     expect(screen.getByText("Remove")).toBeInTheDocument();
     expect(screen.getByLabelText(/view/i)).toBeInTheDocument();
@@ -33,7 +33,12 @@ describe("Tree View", () => {
     render(
       <TreeView
         data={[
-          { id: "1", name: "Parent", data: {}, children: [{ id: "2", name: "Child", data: {} }] },
+          {
+            id: "1",
+            name: "Parent",
+            data: {},
+            children: [{ id: "2", name: "Child", data: { parentId: 1 } }],
+          },
         ]}
       />,
     );
@@ -97,6 +102,12 @@ describe("Tree View", () => {
     render(<TreeView data={[dummyItem]} />);
 
     expect(screen.getByText("Some Type")).toBeInTheDocument();
+  });
+
+  it("should display 'delete' instead of 'remove' if item has no parent", () => {
+    render(<TreeView data={[dummyItem]} />);
+
+    expect(screen.getByText("Delete")).toBeInTheDocument();
   });
 
   it("should expand parents of selected item", () => {

--- a/src/components/visualisation/treeView.tsx
+++ b/src/components/visualisation/treeView.tsx
@@ -82,7 +82,7 @@ export const TreeView = ({
         setCurrentlyLoading(item.id);
         try {
           await onRemove(item);
-        } catch {
+        } finally {
           setCurrentlyLoading(null);
         }
       }
@@ -180,7 +180,9 @@ export const TreeView = ({
                       onClick={() => handleRemove(item)}
                       isLoading={item.id === currentlyLoading}
                     >
-                      Remove
+                      {item.data.containerId || item.data.parentId || item.data.topLevelContainerId
+                        ? "Remove"
+                        : "Delete"}
                     </Button>
                   )}
                 </HStack>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2066](https://jira.diamond.ac.uk/browse/LIMS-2066)

**Summary**:

Previously, a success message would be displayed even if the delete operation failed. Now, only the error message is displayed.

Additionally, if an item is set to be deleted instead of just removed from its parent, then "delete" is displayed instead of "remove" in the tree view

**Changes**:
- Display remove/delete appropriately based on context for tree view
- Fix displaying successful message even on failure

**To test**:
Requires https://github.com/DiamondLightSource/scaup-backend/pull/28

- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/gridBox/new/edit
- Check if the sample on the "unassigned" portion of the tree view has a button that says "delete" next to it
- Create a new grid box and add the existing sample to it
- Check that the button now says "remove"
- Click the "remove button"
- Check if the sample was removed from the grid box, and "delete" is now displayed next to it
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100
- Tick "use existing grids" and create a new shipment
- Set the session to 100 and import at least one grid
- Click save, edit the url to say https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/SHIPMENT_ID/edit (this is the quickest way of getting there)
- Try deleting the sample in "unassigned"
- Check that the error message says "Sample is linked to a different session and cannot be deleted"
