### PR TITLE
Improvements to dewar page

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(view)/[itemType]/[itemId]/layoutContent.test.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(view)/[itemType]/[itemId]/layoutContent.test.tsx
@@ -140,7 +140,7 @@ describe("Item Page Layout Content", () => {
     );
 
     const stepHeading = screen.getAllByRole("heading", {
-      name: /packages/i,
+      name: /dewars/i,
     });
 
     expect(stepHeading[0]).toHaveAttribute("data-status", "active");

--- a/src/components/navigation/ItemStepper.test.tsx
+++ b/src/components/navigation/ItemStepper.test.tsx
@@ -20,7 +20,7 @@ describe("Item Stepper", () => {
     expect(screen.getByLabelText("Grids Step")).toBeInTheDocument();
     expect(screen.getByLabelText("Grid Boxes Step")).toBeInTheDocument();
     expect(screen.getByLabelText("Containers Step")).toBeInTheDocument();
-    expect(screen.getByLabelText("Packages Step")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dewars Step")).toBeInTheDocument();
   });
 
   it("should count item amounts", () => {
@@ -28,7 +28,7 @@ describe("Item Stepper", () => {
       preloadedState: { shipment: { ...testInitialState, items: defaultShipmentItems } },
     });
 
-    expect(screen.getByText(/1 Packages/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 Dewars/i)).toBeInTheDocument();
     expect(screen.getByText(/1 Containers/i)).toBeInTheDocument();
   });
 
@@ -59,7 +59,7 @@ describe("Item Stepper", () => {
     );
 
     const stepHeading = screen.getByRole("heading", {
-      name: /packages/i,
+      name: /dewars/i,
     });
 
     fireEvent.click(stepHeading);

--- a/src/mappings/forms/walkIn.ts
+++ b/src/mappings/forms/walkIn.ts
@@ -13,13 +13,4 @@ export const walkInForm = [
     },
   },
   ...topLevelContainerForm,
-  {
-    id: "code",
-    label: "Dewar Code",
-    type: "dropdown",
-    values: {
-      base: [{ label: "None", value: "" }],
-      $ref: { parent: "#/dewars", map: { value: "facilityCode", label: "facilityCode" } },
-    },
-  },
 ] as DynamicFormEntry[];

--- a/src/mappings/pages.ts
+++ b/src/mappings/pages.ts
@@ -26,9 +26,9 @@ export const steps: Step[] = [
     endpoint: "containers",
   },
   {
-    title: "Packages",
+    title: "Dewars",
     id: ["dewar", "walk-in"],
-    singular: "Package",
+    singular: "Dewar",
     endpoint: "topLevelContainers",
   },
 ];

--- a/src/utils/generic.test.tsx
+++ b/src/utils/generic.test.tsx
@@ -47,9 +47,9 @@ describe("Pointer resolver", () => {
         data,
       ),
     ).toEqual([
-      { result1: 5, result2: 5 },
       { result: 1, result2: 3 },
       { result: 99, result2: 100 },
+      { result1: 5, result2: 5 },
     ]);
   });
 

--- a/src/utils/generic.tsx
+++ b/src/utils/generic.tsx
@@ -42,7 +42,7 @@ export const parseJsonReferences = (pointer: string | JsonRef, pointee: Record<s
       pointerVal = parseArrayUsingMap(ref.map, pointerVal);
     }
 
-    const fullValue = baseArray ? baseArray.concat(pointerVal) : pointerVal;
+    const fullValue = baseArray ? pointerVal.concat(baseArray) : pointerVal;
 
     return fullValue.length < 1 ? null : fullValue;
   }


### PR DESCRIPTION
**Summary**:

To reduce confusion, a few changes were made to the dewar page (renamed from packages).

**Changes**:
- Remove dewar code dropdown from walk-in page
- Rename packages to dewars
- Place generate generate dewar code at end of dropdown

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/dewar/new/edit, check if the dropdown has "Generate Dewar Code" at the end
- Change the type to "Walk-In", check if the dropdown is gone
- Check if the step is now named "Dewars"
