### PR TITLE
[LIMS-2173] Dewar tracking history page

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/booking-and-labels/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/booking-and-labels/page.tsx
@@ -1,29 +1,13 @@
 import { ShipmentParams } from "@/types/generic";
 import { serverFetch } from "@/utils/server/request";
-import {
-  Button,
-  Divider,
-  HStack,
-  Heading,
-  Link,
-  List,
-  ListItem,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
+import { Button, Divider, HStack, Heading, List, ListItem, Text, VStack } from "@chakra-ui/react";
 import { Metadata } from "next";
 import NextLink from "next/link";
 import { ArrangeShipmentButton } from "@/components/navigation/ArrangeShipmentButton";
+import { getIsBooked } from "@/utils/server/shipment";
 
 export const metadata: Metadata = {
   title: "Booking & Labels - Scaup",
-};
-
-const getIsBooked = async (shipmentId: string) => {
-  const res = await serverFetch(`/shipments/${shipmentId}`);
-  const data = res && res.status === 200 ? await res.json() : [];
-
-  return data && !!data.data.shipmentRequest;
 };
 
 const BookingAndLabelsPage = async (props: { params: Promise<ShipmentParams> }) => {

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.test.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.test.tsx
@@ -4,6 +4,7 @@ import { server } from "@/mocks/server";
 import { HttpResponse, http } from "msw";
 import ReturnRequests from "./page";
 import { baseShipmentParams } from "@/utils/test-utils";
+import { defaultData } from "@/mocks/handlers";
 
 describe("Dewar Logistics", () => {
   it("should render available dewars", async () => {
@@ -11,6 +12,20 @@ describe("Dewar Logistics", () => {
 
     expect(screen.getByText(/dewar-001/i)).toBeInTheDocument();
     expect(screen.getByText(/request return/i)).toBeInTheDocument();
+  });
+
+  it("should display 'view shipping info' button if shipment is booked", async () => {
+    server.use(
+      http.get(
+        "http://localhost/api/shipments/:shipmentId",
+        () => HttpResponse.json({ ...defaultData, data: { shipmentRequest: 123 } }),
+        { once: true },
+      ),
+    );
+
+    render(await ReturnRequests(baseShipmentParams));
+
+    expect(screen.getByText(/view shipping information/i)).toBeInTheDocument();
   });
 
   it("should render message if request fails", async () => {

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.tsx
@@ -71,7 +71,7 @@ const ReturnRequests = async (props: { params: Promise<ShipmentParams> }) => {
                   <Heading flex='1 0 0' size='lg'>
                     {tlc.name ?? "Unnamed Dewar"}
                   </Heading>
-                  <ArrangeShipmentButton params={params} isBooked={isBooked} />
+                  {isBooked && <ArrangeShipmentButton params={params} isBooked={isBooked} />}
                   <NextLink href={`${process.env.SYNCHWEB_URL}/dewars/dispatch/${tlc.externalId}`}>
                     <Button>Request Return</Button>
                   </NextLink>

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/dewar-logistics/page.tsx
@@ -21,6 +21,8 @@ import {
 } from "@chakra-ui/react";
 import { Metadata } from "next";
 import NextLink from "next/link";
+import { ArrangeShipmentButton } from "@/components/navigation/ArrangeShipmentButton";
+import { getIsBooked } from "@/utils/server/shipment";
 
 export const metadata: Metadata = {
   title: "Request Returns - Scaup",
@@ -39,6 +41,7 @@ const getTopLevelContainers = async (shipmentId: string) => {
 const ReturnRequests = async (props: { params: Promise<ShipmentParams> }) => {
   const params = await props.params;
   const tlcData = await getTopLevelContainers(params.shipmentId);
+  const isBooked = await getIsBooked(params.shipmentId);
 
   return (
     <VStack gap='0' alignItems='start' w='100%'>
@@ -68,6 +71,7 @@ const ReturnRequests = async (props: { params: Promise<ShipmentParams> }) => {
                   <Heading flex='1 0 0' size='lg'>
                     {tlc.name ?? "Unnamed Dewar"}
                   </Heading>
+                  <ArrangeShipmentButton params={params} isBooked={isBooked} />
                   <NextLink href={`${process.env.SYNCHWEB_URL}/dewars/dispatch/${tlc.externalId}`}>
                     <Button>Request Return</Button>
                   </NextLink>
@@ -80,7 +84,7 @@ const ReturnRequests = async (props: { params: Promise<ShipmentParams> }) => {
                     borderRight='1px solid'
                     borderColor='diamond.100'
                   >
-                    <Heading size='md'>Transport History</Heading>
+                    <Heading size='md'>Internal Tracking History</Heading>
                     <Box w='100%' overflowY='scroll' h='20em' p='1em'>
                       {tlc.history ? (
                         <Stepper index={0} orientation='vertical' maxH='400px' gap='0' size='sm'>

--- a/src/utils/server/shipment.ts
+++ b/src/utils/server/shipment.ts
@@ -25,3 +25,10 @@ export const getShipmentData = async (
     ? ((await res.json()) as components["schemas"]["ShipmentChildren"])
     : null;
 };
+
+export const getIsBooked = async (shipmentId: string) => {
+  const res = await serverFetch(`/shipments/${shipmentId}`);
+  const data = res && res.status === 200 ? await res.json() : [];
+
+  return data && !!data.data.shipmentRequest;
+};


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2173](https://jira.diamond.ac.uk/browse/LIMS-2173)

**Summary**:

To improve clarity and avoid further confusion regarding dewar tracking information, the title has been changed, and a button has been added to allow users to view shipping information

**Changes**:
- Display "view shipping information" button in dewar tracking page
- Update title text in dewar tracking page 

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/117/dewar-logistics, check that a "view shipping information" button is displayed
<img width="1059" height="699" alt="image" src="https://github.com/user-attachments/assets/b937ff48-d8ac-4f2d-9b83-11889f509d65" />
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/102/shipments/229/dewar-logistics , check if the button is no longer displayed
<img width="1158" height="501" alt="image" src="https://github.com/user-attachments/assets/6269b978-cc62-4878-9861-291db4941626" />

