### PR TITLE
[LIMS-2185] Allow multiple shuttles, fix pre-session forms

### DIFF
--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.test.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.test.tsx
@@ -70,17 +70,21 @@ describe("Sample Collection Submission Overview", () => {
     expect(screen.getAllByRole("group")[0]).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("should display Aquilos shuttle for FIB sessions", async () => {
-    server.use(
-      http.get(
-        "http://localhost/api/shipments/:shipmentId",
-        () => HttpResponse.json({ ...defaultData, data: { sessionType: { name: "Aquilos" } } }),
-        { once: true },
-      ),
-    );
-    renderWithProviders(await ShipmentHome(baseShipmentParams));
-    expect(screen.getByText("Shuttle")).toBeInTheDocument();
-  });
+  it.each([{ experimentType: "Aquilos" }, { experimentType: "CLEM" }])(
+    "should display shuttle for $experimentType sessions",
+    async ({ experimentType }) => {
+      server.use(
+        http.get(
+          "http://localhost/api/shipments/:shipmentId",
+          () =>
+            HttpResponse.json({ ...defaultData, data: { sessionType: { name: experimentType } } }),
+          { once: true },
+        ),
+      );
+      renderWithProviders(await ShipmentHome(baseShipmentParams));
+      expect(screen.getByText("Shuttles")).toBeInTheDocument();
+    },
+  );
 
   it("should not enable 'edit pre-session information' button if session is locked", async () => {
     server.use(

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/page.tsx
@@ -136,10 +136,10 @@ const ShipmentHome = async (props: { params: Promise<ShipmentParams> }) => {
                   ))}
                 </VStack>
                 {isStaff && shipmentData.samples ? (
-                  shipmentData.dispatch.sessionType.name === "TEM" ? (
+                  ["TEM", "Talos"].includes(shipmentData.dispatch.sessionType.name) ? (
                     <Cassette samples={shipmentData.samples} />
                   ) : (
-                    <AquilosShuttle samples={shipmentData.samples}></AquilosShuttle>
+                    <AquilosShuttle samples={shipmentData.samples} />
                   )
                 ) : null}
               </HStack>

--- a/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/pre-session/pageContext.test.tsx
+++ b/src/app/proposals/[proposalId]/sessions/[visitNumber]/shipments/[shipmentId]/(default)/pre-session/pageContext.test.tsx
@@ -147,11 +147,7 @@ describe("Item Page Layout", () => {
     mockRouter.setCurrentUrl("/");
 
     renderWithProviders(
-      <PreSessionContent
-        shipmentType={type as SessionType}
-        params={params}
-        prepopData={{}}
-      />,
+      <PreSessionContent shipmentType={type as SessionType} params={params} prepopData={{}} />,
       {
         preloadedState,
       },

--- a/src/components/containers/AquilosShuttle.test.tsx
+++ b/src/components/containers/AquilosShuttle.test.tsx
@@ -19,7 +19,7 @@ describe("Aquilos Shuttle", () => {
   it("should render 2 shuttle slots", () => {
     renderAndInjectForm(<AquilosShuttle samples={[]} />);
 
-    expect(screen.getAllByRole("button")).toHaveLength(2);
+    expect(screen.getAllByRole("button")).toHaveLength(4);
   });
 
   it("should render passed samples", () => {
@@ -31,7 +31,7 @@ describe("Aquilos Shuttle", () => {
   it("should render selectable samples in modal", () => {
     renderAndInjectForm(<AquilosShuttle samples={[{ ...defaultSample, subLocation: null }]} />);
 
-    fireEvent.click(screen.getByText("2"));
+    fireEvent.click(screen.getAllByText("2")[0]);
 
     expect(screen.getByText("aquilos-sample")).toBeInTheDocument();
   });
@@ -39,7 +39,7 @@ describe("Aquilos Shuttle", () => {
   it("should close modal when adding sample", async () => {
     renderAndInjectForm(<AquilosShuttle samples={[{ ...defaultSample, subLocation: null }]} />);
 
-    fireEvent.click(screen.getByText("2"));
+    fireEvent.click(screen.getAllByText("2")[0]);
 
     expect(screen.getByText("aquilos-sample")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("radio"));
@@ -51,7 +51,7 @@ describe("Aquilos Shuttle", () => {
   it("should close modal when removing sample", async () => {
     renderAndInjectForm(<AquilosShuttle samples={[defaultSample]} />);
 
-    fireEvent.click(screen.getByText("1"));
+    fireEvent.click(screen.getAllByText("1")[0]);
     fireEvent.click(screen.getByText("Remove"));
 
     await waitFor(() => expect(screen.queryByText("Apply")).not.toBeInTheDocument());

--- a/src/components/containers/AquilosShuttle.tsx
+++ b/src/components/containers/AquilosShuttle.tsx
@@ -5,9 +5,9 @@ import { TreeData } from "@/types/forms";
 import { BaseShipmentItem } from "@/mappings/pages";
 import {
   Button,
+  Divider,
   Heading,
   HStack,
-  List,
   Spacer,
   Tag,
   Text,
@@ -30,7 +30,7 @@ export const AquilosShuttle = ({ samples }: AquilosShuttleProps) => {
   const [currentPosition, setCurrentPosition] = useState(0);
 
   const items = useMemo<Array<TreeData<PositionedItem> | null>>(() => {
-    const newSamples = Array(2).fill(null);
+    const newSamples = Array(4).fill(null);
     for (const sample of samples) {
       // Populate in reverse
       if (sample.subLocation !== undefined && sample.subLocation !== null) {
@@ -72,37 +72,49 @@ export const AquilosShuttle = ({ samples }: AquilosShuttleProps) => {
         mb='5px'
         pb='3px'
       >
-        Shuttle
+        Shuttles
       </Heading>
       <HStack w='100%'>
-        {items.map((item, i) => (
-          <Button
-            key={i}
-            p='5px'
-            display='flex'
-            bg={item === null ? "diamond.75" : "diamond.700"}
-            mb='3px'
-            borderRadius='4px'
-            onClick={() => handlePositionClicked(item, i)}
-            border='2px solid'
-            borderColor='diamond.700'
-            w='100%'
-          >
-            <Tag colorScheme='teal' minW='30px' justifyContent='center' flexShrink='0'>
-              {i + 1}
-            </Tag>
-            <Text
-              px='10px'
-              fontWeight='600'
-              color={item === null ? "diamond.800" : "diamond.50"}
-              overflowX='hidden'
-              textOverflow='ellipsis'
-            >
-              {item?.name ?? ""}
-            </Text>
-            <Spacer />
-          </Button>
-        ))}
+        <VStack w='100%' alignItems='left' divider={<Divider borderColor='black' />}>
+          {[0, 2].map((shuttleRow, i) => (
+            <>
+              <Heading pt='0.5em' size='sm'>
+                Shuttle {i + 1}
+              </Heading>
+              <HStack key={shuttleRow} w='100%'>
+                {items.slice(shuttleRow, shuttleRow + 2).map((item, j) => (
+                  <Button
+                    key={`{i}-{j}`}
+                    p='5px'
+                    flex='1 0 0'
+                    display='flex'
+                    bg={item === null ? "diamond.75" : "diamond.700"}
+                    mb='3px'
+                    borderRadius='4px'
+                    onClick={() => handlePositionClicked(item, shuttleRow + j)}
+                    border='2px solid'
+                    borderColor='diamond.700'
+                    w='100%'
+                  >
+                    <Tag colorScheme='teal' minW='30px' justifyContent='center' flexShrink='0'>
+                      {j + 1}
+                    </Tag>
+                    <Text
+                      px='10px'
+                      fontWeight='600'
+                      color={item === null ? "diamond.800" : "diamond.50"}
+                      overflowX='hidden'
+                      textOverflow='ellipsis'
+                    >
+                      {item?.name ?? ""}
+                    </Text>
+                    <Spacer />
+                  </Button>
+                ))}
+              </HStack>
+            </>
+          ))}
+        </VStack>
       </HStack>
       <ChildSelector
         childrenType='sample'

--- a/src/mappings/forms/preSessionClem.ts
+++ b/src/mappings/forms/preSessionClem.ts
@@ -68,13 +68,13 @@ export const preSessionClemForm = [
   },
   {
     id: "gfpEt",
-    label: "GFP ET ",
+    label: "GFP ET",
     hint: "Ex: 470/40; Em: 525/50; Dichroic: 495",
     type: "checkbox",
   },
   {
     id: "farRedY5",
-    label: "GFP ET ",
+    label: "Far Red Y5",
     hint: "Ex: BP 620/60; Em: 700/75; Dichroic: 660",
     type: "checkbox",
   },


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2185](https://jira.diamond.ac.uk/browse/LIMS-2185)

**Summary**:

This adds an extra shuttle to CLEM/Aquilos experiments, as multiple shuttles may be used

**Changes**:
- Allow multiple shuttles
- Fix filter cube option title in pre-session information 

**To test**:
If you get an internal server error while creating the CLEM sample collection, pull the latest version of the backend database 

- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100, create a new CLEM sample collection
- Add at least one sample, then go back to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100 and select the sample collection you just created
- Assign the sample to one of the slots (or switch between all 4), check if it all works as expected
- Click "edit sample collection", remove the sample, click continue until you get to the pre-session page
- Check that there is a "Far Red Y5" option for filter cube
